### PR TITLE
README Installation Update and Reduce Dependency Scope of opencv and numpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Replacing the symlink in a directory such as `/usr/bin/python`
 is __not__ recommended because this can potentially break
 other Python 3 applications.
 
-You will also need the following packages.
+You also need the following packages.
 
 * parallel-ssh
 * psutil >= 0.4.1
@@ -40,22 +40,16 @@ You will also need the following packages.
 * six==1.1.0
 * Flask==0.9
 * Flask-RESTful==0.2.1
+* opencv >=2.4 (optional)
+* numpy (optional)
 
+To install:
+    sudo apt-get install gcc python-dev default-jre python-pip pssh python-psutil
+    sudo pip install -r server/requirements.txt
 
-To install, you can either
-
-* run a installation script::
-
-    > $ sudo apt-get install fabric openssh-server
-    
-    > $ fab localhost install
-
-* install manually::
-
-    > sudo apt-get install gcc python-dev default-jre python-pip pssh python-psutil
-    
-    > sudo pip install flask==0.9 flask-restful==0.2.1 six==1.1.0
-
+If you want to save server received video for debugging, you'll also need opencv and numpy library:
+   sudo apt-get install python-opencv
+   sudo pip install numpy
 
 Installation - Default networking interface.
 -------------

--- a/server/bin/gabriel-control
+++ b/server/bin/gabriel-control
@@ -20,9 +20,8 @@
 #
 
 
-import cv2
+
 import json
-import numpy as np
 from optparse import OptionParser
 import os
 import Queue
@@ -115,6 +114,8 @@ class EmulatedMobileDevice(object):
 
                 ## write images into a video
                 if gabriel.Debug.SAVE_VIDEO:
+                    import cv2
+                    import numpy as np
                     img_array = np.asarray(bytearray(image_data), dtype = np.int8)
                     cv_image = cv2.imdecode(img_array, -1)
                     if not self.log_video_writer_created:

--- a/server/gabriel/control/mobile_server.py
+++ b/server/gabriel/control/mobile_server.py
@@ -19,10 +19,9 @@
 #   limitations under the License.
 #
 
-import cv2
+
 import json
 import multiprocessing
-import numpy as np
 import os
 import Queue
 import select
@@ -149,6 +148,8 @@ class MobileVideoHandler(MobileSensorHandler):
 
         ## write images into a video
         if gabriel.Debug.SAVE_VIDEO:
+            import cv2
+            import numpy as np
             img_array = np.asarray(bytearray(image_data), dtype = np.int8)
             cv_image = cv2.imdecode(img_array, -1)
             print cv_image.shape

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,0 +1,7 @@
+Flask==0.9
+Flask-RESTful==0.2.1
+Jinja2==2.8
+MarkupSafe==0.23
+pycrypto==2.6.1
+six==1.1.0
+Werkzeug==0.11.10


### PR DESCRIPTION
1. Moved opencv and numpy dependency to its smallest scope so that normal users don't need to install these two large packages unless they turn on video debug.
2. Removed obsolete fabric installation method in README
3. Add in pip requirement file