### PR TITLE
Fix logging problem

### DIFF
--- a/server/gabriel/common/log.py
+++ b/server/gabriel/common/log.py
@@ -32,6 +32,10 @@ def getLogger(
 
     if loggers.get(name, None) is None:
         logger = logging.getLogger(name)
+        
+        # This passes on every log message to the handlers. 
+        # The actual messages that get logged depend on the level that was
+        # set for each handler.
         logger.setLevel(logging.DEBUG)
 
         # Add stdout logging

--- a/server/gabriel/common/log.py
+++ b/server/gabriel/common/log.py
@@ -25,30 +25,39 @@ import sys
 from .config import Const, Debug
 
 loggers = dict()
-DEFAULT_FORMATTER = '%(asctime)s %(name)s %(levelname)s %(message)s'
 
-def getLogger(name = 'unknown', log_level_file = Debug.LOG_LEVEL_FILE, log_level_console = Debug.LOG_LEVEL_CONSOLE):
+def getLogger(
+        name='unknown', log_level_file=Debug.LOG_LEVEL_FILE,
+        log_level_console=Debug.LOG_LEVEL_CONSOLE):
+
     if loggers.get(name, None) is None:
-        ## default file logging
-        if not os.path.exists(os.path.dirname(Const.LOG_FILE_PATH)):
-            os.makedirs(os.path.dirname(Const.LOG_FILE_PATH))
-            os.chmod(os.path.dirname(Const.LOG_FILE_PATH), 0o777)
-            open(Const.LOG_FILE_PATH, "w+").close()
-            os.chmod(Const.LOG_FILE_PATH, 0o666)
         logger = logging.getLogger(name)
-        logging.basicConfig(level = log_level_file,
-                format = '%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-                datefmt = '%m-%d %H:%M',
-                filename = Const.LOG_FILE_PATH,
-                filemode = 'a')
+        logger.setLevel(logging.DEBUG)
 
-        ## add stdout logging with INFO level
-        console = logging.StreamHandler(sys.stderr)
+        # Add stdout logging
+        console = logging.StreamHandler(sys.stdout)
         console.setLevel(log_level_console)
         formatter = logging.Formatter('%(levelname)-8s %(message)s')
         console.setFormatter(formatter)
         logger.addHandler(console)
 
+        # Add file logging
+        if not os.path.exists(os.path.dirname(Const.LOG_FILE_PATH)):
+            os.makedirs(os.path.dirname(Const.LOG_FILE_PATH))
+            os.chmod(os.path.dirname(Const.LOG_FILE_PATH), 0o777)
+            open(Const.LOG_FILE_PATH, "w+").close()
+            os.chmod(Const.LOG_FILE_PATH, 0o666)
+
+        fileHandler = logging.FileHandler(
+            Const.LOG_FILE_PATH, mode='a')
+        fileHandler.setLevel(log_level_file)
+        formatter = logging.Formatter(
+            '%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+            datefmt='%m-%d %H:%M')
+        fileHandler.setFormatter(formatter)
+        logger.addHandler(fileHandler)
+
         loggers[name] = logger
 
     return loggers.get(name)
+


### PR DESCRIPTION
When Debug.LOG_LEVEL_CONSOLE was set lower than Debug.LOG_LEVEL_FILE, logs at levels less than Debug.LOG_LEVEL_FILE would not get printed to the console. For example, when LOG_LEVEL_FILE was set to logging.ERROR and LOG_LEVEL_CONSOLE was set to logging.INFO, info messages would not get printed to the console. See more details about this issue [here](https://stackoverflow.com/a/17523356/859277).

This change fixes this problem so console messages will be printed based on the value of When Debug.LOG_LEVEL_CONSOLE and file messages will be printed based on the value of Debug.LOG_LEVEL_FILE.

I also fixed some minor issues that I will highlight with inline comments on the pull request.