### PR TITLE
Fix UComm not figuring out its own IP address

### DIFF
--- a/server/bin/gabriel-ucomm
+++ b/server/bin/gabriel-ucomm
@@ -86,7 +86,7 @@ def main():
 
     ## register the current ucomm
     try:
-        register_ucomm(ip_addr, port, settings.address, settings.net_interface)
+        register_ucomm(ip_addr, port, None, settings.net_interface)
     except Exception as e:
         LOG.error(str(e))
         LOG.error("failed to register UCOMM to the control")


### PR DESCRIPTION
A very small error in `bin/gabriel-ucomm` made the UComm service unable to figure out it's own IP independent of the Gabriel core publishing service (as it would just return the IP of gabriel-control by default). This meant that the different components of Gabriel (control, UComm and the application engines) could not be run in separate containers, as the application engine would receive an erroneous IP address for the UComm service from the publishing service in gabriel-control. This change fixes the error, thus allowing fully containerized setups where each component can easily be isolated and run in a dedicated container. 