### PR TITLE
Add ZeroMQ Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ local.properties
 /android-client/captures
 .externalNativeBuild
 .cxx
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Carnegie Mellon University
+#
+# SPDX-License-Identifier: Apache-2.0
+
 *.pyc
 gabriel_client.egg-info/
 gabriel_protocol.egg-info/

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2024 2024 Carnegie Mellon University
+#
+# SPDX-License-Identifier: Apache-2.0
+
+version = 1
+SPDX-PackageName = "Gabriel"
+SPDX-PackageSupplier = "CMU Satyalab"
+
+[[annotations]]
+path = "server/**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2024 Carnegie Mellon University"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "protocol/**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2024 Carnegie Mellon University"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "android-client/**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2024 Carnegie Mellon University"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "python-client/**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2024 Carnegie Mellon University"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "examples/**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2024 Carnegie Mellon University"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ["README.md", "design/README.md", "design/architecture.png"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2024 Carnegie Mellon University"
+SPDX-License-Identifier = "CC0-1.0"

--- a/python-client/README.md
+++ b/python-client/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-Requires Python 3.6 or later.
+Requires Python 3.8 or later.
 
 Run `pip install gabriel-client`
 

--- a/python-client/setup.py
+++ b/python-client/setup.py
@@ -8,6 +8,8 @@ setuptools.setup(
     version="3.0",
     author="Roger Iyengar",
     author_email="ri@rogeriyengar.com",
+    maintainer="CMU Satyalab",
+    maintainer_email="gabriel@cmusatyalab.org",
     description="Networking components for Gabriel Python clients",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/python-client/setup.py
+++ b/python-client/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gabriel-client",
-    version="2.1.1",
+    version="3.0",
     author="Roger Iyengar",
     author_email="ri@rogeriyengar.com",
     description="Networking components for Gabriel Python clients",
@@ -23,7 +23,7 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.11",
     install_requires=[
         "gabriel-protocol==2.0.1",
         "websockets==9.1",

--- a/python-client/setup.py
+++ b/python-client/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     python_requires=">=3.8",
     install_requires=[
         "gabriel-protocol==2.0.1",
-        "websockets==9.1",
+        "websockets>=9.1",
         "opencv-python>=3, <5",
     ],
     extras_require={

--- a/python-client/setup.py
+++ b/python-client/setup.py
@@ -16,17 +16,23 @@ setuptools.setup(
     package_dir={"": "src"},
     license="Apache",
     classifiers=[
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
+        "programming language :: python :: 3.8",
+        "programming language :: python :: 3.9",
+        "programming language :: python :: 3.10",
+        "programming language :: python :: 3.11",
+        "programming language :: python :: 3.12",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.11",
+    python_requires=">=3.8",
     install_requires=[
         "gabriel-protocol==2.0.1",
         "websockets==9.1",
         "opencv-python>=3, <5",
     ],
+    extras_require={
+        'zmq': [
+            "pyzmq>=18.1",
+        ],
+    }
 )

--- a/python-client/src/gabriel_client/source.py
+++ b/python-client/src/gabriel_client/source.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
 
+logger = logging.getLogger(__name__)
+
 class _Source:
     def __init__(self, num_tokens):
         self._num_tokens = num_tokens

--- a/python-client/src/gabriel_client/source.py
+++ b/python-client/src/gabriel_client/source.py
@@ -17,8 +17,6 @@ class _Source:
         await self._sem.acquire()
         logger.debug('Token acquired')
 
-        self._num_tokens -= 1
-
     def is_locked(self):
         return self._sem.locked()
 

--- a/python-client/src/gabriel_client/source.py
+++ b/python-client/src/gabriel_client/source.py
@@ -1,0 +1,29 @@
+import asyncio
+import logging
+
+class _Source:
+    def __init__(self, num_tokens):
+        self._num_tokens = num_tokens
+        self._event = asyncio.Event()
+        self._frame_id = 0
+
+    def return_token(self):
+        self._num_tokens += 1
+        self._event.set()
+
+    async def get_token(self):
+        while self._num_tokens < 1:
+            logger.debug('Waiting for token')
+            self._event.clear()  # Clear because we definitely want to wait
+            await self._event.wait()
+
+        self._num_tokens -= 1
+
+    def get_num_tokens(self):
+        return self._num_tokens
+
+    def get_frame_id(self):
+        return self._frame_id
+
+    def next_frame(self):
+        self._frame_id += 1

--- a/python-client/src/gabriel_client/websocket_client.py
+++ b/python-client/src/gabriel_client/websocket_client.py
@@ -153,8 +153,8 @@ class WebsocketClient:
             except websockets.exceptions.ConnectionClosed:
                 return  # stop the handler
 
-            logger.debug('num_tokens for %s is now %d', source_name,
-                         source.get_num_tokens())
+            logger.debug('Semaphore for %s is %s', source_name,
+                         "LOCKED" if source.is_locked() else "AVAILABLE")
             source.next_frame()
 
     async def _send_from_client(self, from_client):

--- a/python-client/src/gabriel_client/websocket_client.py
+++ b/python-client/src/gabriel_client/websocket_client.py
@@ -3,8 +3,10 @@ import logging
 import socket
 import websockets
 import websockets.client
+
 from gabriel_protocol import gabriel_pb2
 from collections import namedtuple
+from gabriel_client.source import _Source
 
 
 URI_FORMAT = 'ws://{host}:{port}'
@@ -159,31 +161,3 @@ class WebsocketClient:
         # Removing this method will break measurement_client
 
         await self._websocket.send(from_client.SerializeToString())
-
-
-class _Source:
-    def __init__(self, num_tokens):
-        self._num_tokens = num_tokens
-        self._event = asyncio.Event()
-        self._frame_id = 0
-
-    def return_token(self):
-        self._num_tokens += 1
-        self._event.set()
-
-    async def get_token(self):
-        while self._num_tokens < 1:
-            logger.debug('Waiting for token')
-            self._event.clear()  # Clear because we definitely want to wait
-            await self._event.wait()
-
-        self._num_tokens -= 1
-
-    def get_num_tokens(self):
-        return self._num_tokens
-
-    def get_frame_id(self):
-        return self._frame_id
-
-    def next_frame(self):
-        self._frame_id += 1

--- a/python-client/src/gabriel_client/zeromq_client.py
+++ b/python-client/src/gabriel_client/zeromq_client.py
@@ -234,8 +234,8 @@ class ZeroMQClient:
             # Send input to server
             await socket.send(from_client.SerializeToString())
 
-            logger.debug('num_tokens for %s is now %d', source_name,
-                         source.get_num_tokens())
+            logger.debug('Semaphore for %s is %s', source_name,
+                         "LOCKED" if source.is_locked() else "AVAILABLE")
             source.next_frame()
 
     async def _send_heartbeat(self):

--- a/python-client/src/gabriel_client/zeromq_client.py
+++ b/python-client/src/gabriel_client/zeromq_client.py
@@ -110,7 +110,7 @@ class ZeroMQClient:
                     self._connected.clear()
                 else:
                     # Resend heartbeat in case it was lost
-                    logger.debug("Still disconnected; reconnecting and resending heartbeat")
+                    logger.info("Still disconnected; reconnecting and resending heartbeat")
                     self._socket.close(0)
                     self._socket = context.socket(zmq.DEALER)
                     self._socket.connect(self._uri)

--- a/python-client/src/gabriel_client/zeromq_client.py
+++ b/python-client/src/gabriel_client/zeromq_client.py
@@ -109,14 +109,15 @@ class ZeroMQClient:
                     logger.info("Disconnected from server")
                     self._connected.clear()
                 else:
-                    # Resend heartbeat in case it was lost
                     logger.info("Still disconnected; reconnecting and resending heartbeat")
-                    self._sock.close(0)
-                    self._sock = context.socket(zmq.DEALER)
-                    self._sock.connect(self._uri)
 
-                    # Send heartbeat even though we are disconnected
-                    await self._send_heartbeat(True)
+                # Resend heartbeat in case it was lost
+                self._sock.close(0)
+                self._sock = context.socket(zmq.DEALER)
+                self._sock.connect(self._uri)
+
+                # Send heartbeat even though we are disconnected
+                await self._send_heartbeat(True)
                 continue
 
             raw_input = await self._sock.recv()

--- a/python-client/src/gabriel_client/zeromq_client.py
+++ b/python-client/src/gabriel_client/zeromq_client.py
@@ -67,7 +67,7 @@ class ZeroMQClient:
         self._connected.set()
 
     async def launch_async(self):
-        asyncio.create_task(self._launch_helper())
+        await self._launch_helper()
 
     def launch(self, message_max_size=None):
         """

--- a/python-client/src/gabriel_client/zeromq_client.py
+++ b/python-client/src/gabriel_client/zeromq_client.py
@@ -208,7 +208,7 @@ class ZeroMQClient:
             try:
                 # Wait for a token. Time out to send a heartbeat to the server.
                 await asyncio.wait_for(source.get_token(), timeout=HEARTBEAT_INTERVAL)
-            except TimeoutError:
+            except (TimeoutError, asyncio.TimeoutError):
                 self._schedule_heartbeat.set()
                 continue
             # Stop producing inputs if disconnected from the server
@@ -229,7 +229,7 @@ class ZeroMQClient:
                 # task cancellation.
                 input_frame = await asyncio.wait_for(
                     asyncio.shield(producer_task), timeout=HEARTBEAT_INTERVAL)
-            except TimeoutError:
+            except (TimeoutError, asyncio.TimeoutError):
                 source.return_token()
                 self._schedule_heartbeat.set()
                 await asyncio.sleep(0)

--- a/python-client/src/gabriel_client/zeromq_client.py
+++ b/python-client/src/gabriel_client/zeromq_client.py
@@ -1,0 +1,126 @@
+import asyncio
+from collections import namedtuple
+from gabriel_protocol import gabriel_pb2
+import logging
+import zmq
+import zmq.asyncio
+
+URI_FORMAT = 'tcp://{host}:{port}'
+
+logger = logging.getLogger(__name__)
+
+ProducerWrapper = namedtuple('ProducerWrapper', ['producer', 'source_name'])
+
+# ZeroMQ setup
+context = zmq.Context()
+socket = context.socket(zmq.DEALER)
+
+class ZeroMQClient:
+    def __init__(self, host, port, producer_wrappers, consumer):
+        self._welcome_event = asyncio.Event()
+        self._sources = {}
+        self._running = True
+        self._uri = URI_FORMAT.format(host=host, port=port)
+        self.producer_wrappers = producer_wrappers
+        self.consumer = consumer
+
+    def launch(self, message_max_size=None):
+        socket.connect(self._uri)
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(_consumer_handler())
+            for producer_wrapper in self.producer_wrappers:
+                tg.create_task(self._producer_handler(
+                    producer_wrapper.producer, producer_wrapper.source_name))
+
+    async def _consumer_handler(self):
+        while self._running:
+            try:
+                raw_input = await socket.recv()
+            logger.debug('Recieved input from server')
+
+            to_client = gabriel_pb2.ToClient()
+            to_client.ParseFromString(raw_input)
+
+            if to_client.HasField('welcome'):
+                self._process_welcome(to_client.welcome)
+            elif to_client.HasField('response'):
+                self._process_response(to_client.response)
+            else:
+                raise Exception('Empty to_client message')
+
+    def _process_welcome(self, welcome):
+        for source_name in welcome.sources_consumed:
+            self._sources[source_name] = _Source(welcome.num_tokens_per_source)
+        self._welcome_event.set()
+
+    def _process_response(self, response):
+        result_wrapper = response.result_wrapper
+        if (result_wrapper.status == gabriel_pb2.ResultWrapper.SUCCESS):
+            self.consumer(result_wrapper)
+        elif (result_wrapper.status ==
+              gabriel_pb2.ResultWrapper.NO_ENGINE_FOR_SOURCE):
+            raise Exception('No engine for source')
+        else:
+            status = result_wrapper.Status.Name(result_wrapper.status)
+            logger.error('Output status was: %s', status)
+
+        if response.return_token:
+            self._sources[response.source_name].return_token()
+
+    async def _producer_handler(self, producer, source_name):
+        '''
+        Loop waiting until there is a token available. Then calls producer to
+        get the gabriel_pb2.InputFrame to send.
+        '''
+
+        await self._welcome_event.wait()
+        source = self._sources.get(source_name)
+        assert source is not None, (
+            "No engines consume frames from source: {}".format(source_name))
+
+        while self._running:
+            await source.get_token()
+
+            input_frame = await producer()
+            if input_frame is None:
+                source.return_token()
+                logger.info('Received None from producer')
+                continue
+
+            from_client = gabriel_pb2.FromClient()
+            from_client.frame_id = source.get_frame_id()
+            from_client.source_name = source_name
+            from_client.input_frame.CopyFrom(input_frame)
+
+            await socket.send(from_client)
+
+            logger.debug('num_tokens for %s is now %d', source_name,
+                         source.get_num_tokens())
+            source.next_frame()
+
+class _Source:
+    def __init__(self, num_tokens):
+        self._num_tokens = num_tokens
+        self._event = asyncio.Event()
+        self._frame_id = 0
+
+    def return_token(self):
+        self._num_tokens += 1
+        self._event.set()
+
+    async def get_token(self):
+        while self._num_tokens < 1:
+            logger.debug('Waiting for token')
+            self._event.clear()  # Clear because we definitely want to wait
+            await self._event.wait()
+
+        self._num_tokens -= 1
+
+    def get_num_tokens(self):
+        return self._num_tokens
+
+    def get_frame_id(self):
+        return self._frame_id
+
+    def next_frame(self):
+        self._frame_id += 1

--- a/python-client/src/gabriel_client/zeromq_client.py
+++ b/python-client/src/gabriel_client/zeromq_client.py
@@ -145,6 +145,7 @@ class ZeroMQClient:
                 logger.debug('Processing response from server')
                 self._process_response(to_client.response)
             else:
+                logger.critical("Fatal error: empty to_client message received from server")
                 raise Exception('Empty to_client message')
 
     def _process_welcome(self, welcome):
@@ -179,6 +180,7 @@ class ZeroMQClient:
                 logger.error(f"Error processing response from server: {e}")
         elif (result_wrapper.status ==
               gabriel_pb2.ResultWrapper.NO_ENGINE_FOR_SOURCE):
+            logger.critical("Fatal error: no engine for source")
             raise Exception('No engine for source')
         else:
             status = result_wrapper.Status.Name(result_wrapper.status)

--- a/python-client/src/gabriel_client/zeromq_client.py
+++ b/python-client/src/gabriel_client/zeromq_client.py
@@ -65,6 +65,9 @@ class ZeroMQClient:
 
         self._connected.set()
 
+    async def launch_async(self):
+        asyncio.create_task(self._launch_helper())
+
     def launch(self, message_max_size=None):
         """
         Launch the client.

--- a/server/README.md
+++ b/server/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-Requires Python 3.6 or newer.
+Requires Python 3.8 or newer.
 
 Run `pip install gabriel-server`
 

--- a/server/setup.py
+++ b/server/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     python_requires=">=3.8",
     install_requires=[
         "gabriel-protocol==2.0.1",
-        "websockets==9.1",
+        "websockets>=9.1",
         "pyzmq>=18.1",
     ],
 )

--- a/server/setup.py
+++ b/server/setup.py
@@ -29,6 +29,6 @@ setuptools.setup(
     install_requires=[
         "gabriel-protocol==2.0.1",
         "websockets==9.1",
-        "pyzmq==18.1",
+        "pyzmq>=18.1",
     ],
 )

--- a/server/setup.py
+++ b/server/setup.py
@@ -18,13 +18,15 @@ setuptools.setup(
     package_dir={"": "src"},
     license="Apache",
     classifiers=[
+        "programming language :: python :: 3.8",
+        "programming language :: python :: 3.9",
+        "programming language :: python :: 3.10",
         "programming language :: python :: 3.11",
         "programming language :: python :: 3.12",
-        "programming language :: python :: 3.13",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.11",
+    python_requires=">=3.8",
     install_requires=[
         "gabriel-protocol==2.0.1",
         "websockets==9.1",

--- a/server/setup.py
+++ b/server/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gabriel-server",
-    version="2.1.1",
+    version="3.0",
     author="Roger Iyengar",
     author_email="ri@rogeriyengar.com",
     description="Server for Wearable Cognitive Assistance Applications",
@@ -18,14 +18,13 @@ setuptools.setup(
     package_dir={"": "src"},
     license="Apache",
     classifiers=[
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
+        "programming language :: python :: 3.11",
+        "programming language :: python :: 3.12",
+        "programming language :: python :: 3.13",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.11",
     install_requires=[
         "gabriel-protocol==2.0.1",
         "websockets==9.1",

--- a/server/setup.py
+++ b/server/setup.py
@@ -10,6 +10,8 @@ setuptools.setup(
     version="3.0",
     author="Roger Iyengar",
     author_email="ri@rogeriyengar.com",
+    maintainer="CMU Satyalab",
+    maintainer="gabriel@cmusatyalab.org",
     description="Server for Wearable Cognitive Assistance Applications",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/server/src/gabriel_server/gabriel_server.py
+++ b/server/src/gabriel_server/gabriel_server.py
@@ -1,0 +1,167 @@
+import asyncio
+import logging
+from gabriel_protocol import gabriel_pb2
+from gabriel_protocol.gabriel_pb2 import ResultWrapper
+from abc import ABC
+from abc import abstractmethod
+from collections import namedtuple
+
+logger = logging.getLogger(__name__)
+
+class GabrielServer(ABC):
+    """
+    Connects to Gabriel clients. Consumes input from the clients
+    and passes it to the specified callback function. Results are sent back to
+    the client as they become available.
+    """
+    def __init__(self, num_tokens_per_source, engine_cb):
+        """
+        Args:
+            num_tokens_per_source (int):
+                The number of tokens available for each source
+            engine_cb:
+                Callback invoked for each input received from a client
+        """
+
+        # Metadata for each client. 'tokens_for_source' is a dictionary that stores
+        # the tokens available for each source. 'task' is an async task that consumes
+        # inputs from 'inputs' for each client.
+        self._Client = namedtuple('_Client', ['tokens_for_source', 'inputs', 'task'])
+        self._num_tokens_per_source = num_tokens_per_source
+        # The clients connected to the server
+        self._clients = {}
+        # The sources consumed by the server
+        self._sources_consumed = set()
+        # Indicates that the server start up is finished
+        self._start_event = asyncio.Event()
+        self._is_running = False
+        self._engine_cb = engine_cb
+
+    @abstractmethod
+    def launch(self, port, message_max_size):
+        pass
+
+    async def wait_for_start(self):
+        await self._start_event.wait()
+
+    async def send_result_wrapper(
+            self, address, source_name, frame_id, result_wrapper, return_token):
+        """
+        Send result to client at address.
+
+        Args:
+            address: The identifier of the client to send the result to
+            source_name: The name of the source that the result corresponds to
+            frame_id: The frame id of the input that the result corresponds to
+            result_wrapper: The result payload to send to the client
+            return_token: Whether to return a token to the client
+
+        Returns True if send succeeded.
+        """
+        client = self._clients.get(address)
+        if client is None:
+            logger.warning('Send request to invalid address: %s', address)
+            return False
+
+        if source_name not in client.tokens_for_source:
+            logger.warning('Send request with invalid source: %s', source_name)
+            # Still send so client gets back token
+        elif return_token:
+            client.tokens_for_source[source_name] += 1
+
+        to_client = gabriel_pb2.ToClient()
+        to_client.response.source_name = source_name
+        to_client.response.frame_id = frame_id
+        to_client.response.return_token = return_token
+        to_client.response.result_wrapper.CopyFrom(result_wrapper)
+
+        return await self.send_via_transport(address, to_client.SerializeToString())
+    
+    @abstractmethod
+    async def send_via_transport(self, address, payload):
+        pass
+
+    def add_source_consumed(self, source_name):
+        """
+        Indicate that at least one cognitive engine consumes frames from
+        source_name.
+
+        Args:
+            source_name (str): The name of the source to add
+
+        Must be called before self.launch() or run on the same event loop that
+        self.launch() uses.
+        """
+
+        if source_name in self._sources_consumed:
+            return
+
+        self._sources_consumed.add(source_name)
+        for client in self._clients.values():
+            client.tokens_for_source[source_name] = self._num_tokens_per_source
+            # TODO inform client about new source
+
+    def remove_source_consumed(self, source_name):
+        """
+        Indicate that all cognitive engines that consumed frames from source
+        have stopped.
+
+        Args:
+            source_name (str): The name of the source to remove
+
+        Must be called before self.launch() or run on the same event loop that
+        self.launch() uses.
+        """
+        if source_name not in self._sources_consumed:
+            return
+
+        self._sources_consumed.remove(source_name)
+        for client in self._clients.values():
+            del client.tokens_for_source[source_name]
+            # TODO inform client source was removed
+
+    @abstractmethod
+    def is_running(self):
+        pass
+
+    @abstractmethod
+    async def _handler(self):
+        pass
+
+    @abstractmethod
+    async def _consumer(self, address):
+        """
+        Consumes client inputs. Sends an error message to the client on failure.
+
+        Args:
+            address: the identifier of the client to consume inputs for
+        """
+        pass
+
+    async def _consumer_helper(self, client, address, from_client):
+        """
+        Send the input to the engine callback.
+
+        Args:
+            client: The client that the input is from
+            address: The identifier of the client
+            from_client: A FromClient protobuf message containing the input
+        """
+        source_name = from_client.source_name
+        if source_name not in self._sources_consumed:
+            logger.error('No engines consume frames from %s', source_name)
+            return ResultWrapper.Status.NO_ENGINE_FOR_SOURCE
+
+        if client.tokens_for_source[source_name] < 1:
+            logger.error(
+                'Client %s sending from source %s without tokens', address,
+                source_name)
+            return ResultWrapper.Status.NO_TOKENS
+
+        logging.debug(f"Sending input from client {address} to engine")
+        send_success = await self._engine_cb(from_client, address)
+        if send_success:
+            return ResultWrapper.Status.SUCCESS
+        else:
+            logger.error('Server dropped frame from: %s', source_name)
+            return gabriel_pb2.ResultWrapper.Status.SERVER_DROPPED_FRAME

--- a/server/src/gabriel_server/gabriel_server.py
+++ b/server/src/gabriel_server/gabriel_server.py
@@ -76,10 +76,10 @@ class GabrielServer(ABC):
         to_client.response.return_token = return_token
         to_client.response.result_wrapper.CopyFrom(result_wrapper)
 
-        return await self.send_via_transport(address, to_client.SerializeToString())
+        return await self._send_via_transport(address, to_client.SerializeToString())
 
     @abstractmethod
-    async def send_via_transport(self, address, payload):
+    async def _send_via_transport(self, address, payload):
         """
         Send a payload to the client at the specified address.
 

--- a/server/src/gabriel_server/gabriel_server.py
+++ b/server/src/gabriel_server/gabriel_server.py
@@ -166,7 +166,7 @@ class GabrielServer(ABC):
                 source_name)
             return ResultWrapper.Status.NO_TOKENS
 
-        logging.debug(f"Sending input from client {address} to engine")
+        logger.debug(f"Sending input from client {address} to engine")
         send_success = await self._engine_cb(from_client, address)
         if send_success:
             return ResultWrapper.Status.SUCCESS

--- a/server/src/gabriel_server/local_engine.py
+++ b/server/src/gabriel_server/local_engine.py
@@ -5,16 +5,19 @@ import os
 from gabriel_protocol import gabriel_pb2
 from gabriel_server import cognitive_engine
 from gabriel_server.websocket_server import WebsocketServer
+from gabriel_server.zeromq_server import ZeroMQServer
 
 
 logger = logging.getLogger(__name__)
 
 
 def run(engine_factory, source_name, input_queue_maxsize, port, num_tokens,
-        message_max_size=None):
+        message_max_size=None, use_zeromq=False):
     engine_conn, server_conn = multiprocessing.Pipe()
 
-    local_server = _LocalServer(num_tokens, input_queue_maxsize, server_conn)
+    local_server = None
+    local_server = (_ZeroMQLocalServer if use_zeromq else _LocalServer)(
+        num_tokens, input_queue_maxsize, server_conn)
     local_server.add_source_consumed(source_name)
 
     engine_process = multiprocessing.Process(
@@ -24,6 +27,42 @@ def run(engine_factory, source_name, input_queue_maxsize, port, num_tokens,
 
     raise Exception('Server stopped')
 
+
+class _ZeroMQLocalServer(ZeroMQServer):
+    def __init__(self, num_tokens_per_source, input_queue_maxsize, conn):
+        super().__init__(num_tokens_per_source)
+        self._input_queue = asyncio.Queue(input_queue_maxsize)
+        self._conn = conn
+        self._result_ready = asyncio.Event()
+
+    async def _send_to_engine(self, from_client, address):
+        if self._input_queue.full():
+            return False
+
+        self._input_queue.put_nowait((from_client, address))
+        return True
+
+    def launch(self, port, message_max_size):
+        asyncio.get_event_loop().add_reader(
+            self._conn.fileno(), self._result_ready.set)
+        asyncio.ensure_future(self._engine_comm())
+        super().launch(port, message_max_size)
+
+    async def _engine_comm(self):
+        await self.wait_for_start()
+        while self.is_running():
+            from_client, address = await self._input_queue.get()
+            self._conn.send_bytes(from_client.input_frame.SerializeToString())
+            result_wrapper = gabriel_pb2.ResultWrapper()
+
+            while not self._conn.poll():
+                await self._result_ready.wait()
+                self._result_ready.clear()
+
+            result_wrapper.ParseFromString(self._conn.recv_bytes())
+            await self.send_result_wrapper(
+                address, from_client.source_name, from_client.frame_id,
+                result_wrapper, return_token=True)
 
 class _LocalServer(WebsocketServer):
     def __init__(self, num_tokens_per_source, input_queue_maxsize, conn):

--- a/server/src/gabriel_server/local_engine.py
+++ b/server/src/gabriel_server/local_engine.py
@@ -15,10 +15,7 @@ def run(engine_factory, source_name, input_queue_maxsize, port, num_tokens,
         message_max_size=None, use_zeromq=False):
     engine_conn, server_conn = multiprocessing.Pipe()
 
-    local_server = None
-    local_server = (_ZeroMQLocalServer if use_zeromq else _LocalServer)(
-        num_tokens, input_queue_maxsize, server_conn)
-    local_server.add_source_consumed(source_name)
+    local_server = _LocalServer(num_tokens, input_queue_maxsize, server_conn, source_name, use_zeromq)
 
     engine_process = multiprocessing.Process(
         target=_run_engine, args=(engine_factory, engine_conn))
@@ -27,13 +24,14 @@ def run(engine_factory, source_name, input_queue_maxsize, port, num_tokens,
 
     raise Exception('Server stopped')
 
-
-class _ZeroMQLocalServer(ZeroMQServer):
-    def __init__(self, num_tokens_per_source, input_queue_maxsize, conn):
-        super().__init__(num_tokens_per_source)
+class _LocalServer:
+    def __init__(self, num_tokens_per_source, input_queue_maxsize, conn, source_name, use_zeromq):
         self._input_queue = asyncio.Queue(input_queue_maxsize)
         self._conn = conn
         self._result_ready = asyncio.Event()
+        self._client_server = (
+            ZeroMQServer if use_zeromq else WebsocketServer)(num_tokens_per_source, self._send_to_engine)
+        self._client_server.add_source_consumed(source_name)
 
     async def _send_to_engine(self, from_client, address):
         if self._input_queue.full():
@@ -46,11 +44,11 @@ class _ZeroMQLocalServer(ZeroMQServer):
         asyncio.get_event_loop().add_reader(
             self._conn.fileno(), self._result_ready.set)
         asyncio.ensure_future(self._engine_comm())
-        super().launch(port, message_max_size)
+        self._client_server.launch(port, message_max_size)
 
     async def _engine_comm(self):
-        await self.wait_for_start()
-        while self.is_running():
+        await self._client_server.wait_for_start()
+        while self._client_server.is_running():
             from_client, address = await self._input_queue.get()
             self._conn.send_bytes(from_client.input_frame.SerializeToString())
             result_wrapper = gabriel_pb2.ResultWrapper()
@@ -60,43 +58,7 @@ class _ZeroMQLocalServer(ZeroMQServer):
                 self._result_ready.clear()
 
             result_wrapper.ParseFromString(self._conn.recv_bytes())
-            await self.send_result_wrapper(
-                address, from_client.source_name, from_client.frame_id,
-                result_wrapper, return_token=True)
-
-class _LocalServer(WebsocketServer):
-    def __init__(self, num_tokens_per_source, input_queue_maxsize, conn):
-        super().__init__(num_tokens_per_source)
-        self._input_queue = asyncio.Queue(input_queue_maxsize)
-        self._conn = conn
-        self._result_ready = asyncio.Event()
-
-    async def _send_to_engine(self, from_client, address):
-        if self._input_queue.full():
-            return False
-
-        self._input_queue.put_nowait((from_client, address))
-        return True
-
-    def launch(self, port, message_max_size):
-        asyncio.get_event_loop().add_reader(
-            self._conn.fileno(), self._result_ready.set)
-        asyncio.ensure_future(self._engine_comm())
-        super().launch(port, message_max_size)
-
-    async def _engine_comm(self):
-        await self.wait_for_start()
-        while self.is_running():
-            from_client, address = await self._input_queue.get()
-            self._conn.send_bytes(from_client.input_frame.SerializeToString())
-            result_wrapper = gabriel_pb2.ResultWrapper()
-
-            while not self._conn.poll():
-                await self._result_ready.wait()
-                self._result_ready.clear()
-
-            result_wrapper.ParseFromString(self._conn.recv_bytes())
-            await self.send_result_wrapper(
+            await self._client_server.send_result_wrapper(
                 address, from_client.source_name, from_client.frame_id,
                 result_wrapper, return_token=True)
 

--- a/server/src/gabriel_server/local_engine.py
+++ b/server/src/gabriel_server/local_engine.py
@@ -3,7 +3,6 @@ import logging
 import multiprocessing
 import os
 from gabriel_protocol import gabriel_pb2
-from gabriel_server import cognitive_engine
 from gabriel_server.websocket_server import WebsocketServer
 from gabriel_server.zeromq_server import ZeroMQServer
 

--- a/server/src/gabriel_server/network_engine/server_runner.py
+++ b/server/src/gabriel_server/network_engine/server_runner.py
@@ -30,18 +30,18 @@ def run(client_port, zmq_address, num_tokens, input_queue_maxsize,
     zmq_socket.bind(zmq_address)
     logger.info('Waiting for engines to connect')
 
-    client_server = (ZeroMQServer if use_zeromq else WebsocketServer)(num_tokens)
-    server = _Server(num_tokens, zmq_socket, timeout, input_queue_maxsize)
+    server = _Server(num_tokens, zmq_socket, timeout, input_queue_maxsize, use_zeromq)
     server.launch(client_port, message_max_size)
 
 class _Server:
-    def __init__(self, num_tokens, zmq_socket, timeout, size_for_queues, client_server):
+    def __init__(self, num_tokens, zmq_socket, timeout, size_for_queues, use_zeromq):
         self._zmq_socket = zmq_socket
         self._engine_workers = {}
         self._source_infos = {}
         self._timeout = timeout
         self._size_for_queues = size_for_queues
-        self._client_server = client_server
+        self._client_server = (
+            ZeroMQServer if use_zeromq else WebsocketServer)(num_tokens, self._send_to_engine)
 
     def launch(self, client_port, message_max_size):
         async def receive_from_engine_worker_loop():
@@ -88,7 +88,7 @@ class _Server:
         if (latest_input is not None and
             latest_input.metadata == engine_worker_metadata):
             # Send response to client
-            await self.send_result_wrapper(
+            await self._client_server.send_result_wrapper(
                 engine_worker_metadata.client_address, source_info.get_name(),
                 engine_worker_metadata.frame_id, result_wrapper,
                 return_token=True)
@@ -96,7 +96,7 @@ class _Server:
             return
 
         if engine_worker.get_all_responses_required():
-            await self.send_result_wrapper(
+            await self._client_server.send_result_wrapper(
                 engine_worker_metadata.client_address, source_info.get_name(),
                 engine_worker_metadata.frame_id, result_wrapper,
                 return_token=False)
@@ -159,7 +159,7 @@ class _Server:
                 # Return token for frame engine was in the middle of processing
                 status = gabriel_pb2.ResultWrapper.Status.ENGINE_ERROR
                 result_wrapper = cognitive_engine.create_result_wrapper(status)
-                await self.send_result_wrapper(
+                await self._client_server.send_result_wrapper(
                     current_input_metadata.client_address,
                     source_info.get_name(), current_input_metadata.frame_id,
                     result_wrapper, return_token=True)
@@ -172,7 +172,7 @@ class _Server:
                 logger.info('No remaining engines consume input from source: '
                             '%s', source_name)
                 del self._source_infos[source_name]
-                self.remove_source_consumed(source_name)
+                self._client_server.remove_source_consumed(source_name)
 
     async def _send_to_engine(self, from_client, client_address):
         source_info = self._source_infos[from_client.source_name]

--- a/server/src/gabriel_server/network_engine/server_runner.py
+++ b/server/src/gabriel_server/network_engine/server_runner.py
@@ -23,7 +23,7 @@ Metadata = namedtuple('Metadata', ['frame_id', 'client_address'])
 MetadataPayload = namedtuple('MetadataPayload', ['metadata', 'payload'])
 
 
-def run(client_port, zmq_address, num_tokens, input_queue_maxsize,
+def run(websocket_port, zmq_address, num_tokens, input_queue_maxsize,
         timeout=FIVE_SECONDS, message_max_size=None, use_zeromq=False):
     context = zmq.asyncio.Context()
     zmq_socket = context.socket(zmq.ROUTER)
@@ -31,7 +31,7 @@ def run(client_port, zmq_address, num_tokens, input_queue_maxsize,
     logger.info('Waiting for engines to connect')
 
     server = _Server(num_tokens, zmq_socket, timeout, input_queue_maxsize, use_zeromq)
-    server.launch(client_port, message_max_size)
+    server.launch(websocket_port, message_max_size)
 
 class _Server:
     def __init__(self, num_tokens, zmq_socket, timeout, size_for_queues, use_zeromq):

--- a/server/src/gabriel_server/websocket_server.py
+++ b/server/src/gabriel_server/websocket_server.py
@@ -38,7 +38,7 @@ class WebsocketServer(GabrielServer):
         self._start_event.set()
         event_loop.run_forever()
 
-    async def send_via_transport(self, address, payload):
+    async def _send_via_transport(self, address, payload):
         logger.debug('Sending to address: %s', address)
         try:
             await self._clients.get(address).websocket.send(payload)

--- a/server/src/gabriel_server/websocket_server.py
+++ b/server/src/gabriel_server/websocket_server.py
@@ -3,22 +3,11 @@ import logging
 import socket
 from gabriel_protocol import gabriel_pb2
 from gabriel_protocol.gabriel_pb2 import ResultWrapper
+from gabriel_server import GabrielServer
 import websockets
 import websockets.server
-from abc import ABC
-from abc import abstractmethod
-from collections import namedtuple
-
 
 logger = logging.getLogger(__name__)
-websockets_logger = logging.getLogger(websockets.__name__)
-
-# The entire payload will be logged if this is allowed to be DEBUG
-websockets_logger.setLevel(logging.INFO)
-
-
-_Client = namedtuple('_Client', ['tokens_for_source', 'websocket'])
-
 
 # It isn't necessary to do this as of Python 3.6 because
 # "The socket option TCP_NODELAY is set by default for all TCP connections"
@@ -31,14 +20,10 @@ class NoDelayProtocol(websockets.server.WebSocketServerProtocol):
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
 
-class WebsocketServer(ABC):
+class WebsocketServer(GabrielServer):
     def __init__(self, num_tokens_per_source, engine_cb):
-        self._num_tokens_per_source = num_tokens_per_source
-        self._clients = {}
-        self._sources_consumed = set()
+        super.__init(num_tokens_per_source, engine_cb)
         self._server = None
-        self._start_event = asyncio.Event()
-        self._engine_cb = engine_cb
 
     def launch(self, port, message_max_size):
         event_loop = asyncio.get_event_loop()
@@ -53,70 +38,15 @@ class WebsocketServer(ABC):
         self._start_event.set()
         event_loop.run_forever()
 
-    async def wait_for_start(self):
-        await self._start_event.wait()
-
-    async def send_result_wrapper(
-            self, address, source_name, frame_id, result_wrapper, return_token):
-        '''Send result to client at address.
-
-        Returns True if send succeeded.'''
-
-        client = self._clients.get(address)
-        if client is None:
-            logger.warning('Send request to invalid address: %s', address)
-            return False
-
-        if source_name not in client.tokens_for_source:
-            logger.warning('Send request with invalid source: %s', source_name)
-            # Still send so client gets back token
-        elif return_token:
-            client.tokens_for_source[source_name] += 1
-
-        to_client = gabriel_pb2.ToClient()
-        to_client.response.source_name = source_name
-        to_client.response.frame_id = frame_id
-        to_client.response.return_token = return_token
-        to_client.response.result_wrapper.CopyFrom(result_wrapper)
-
+    async def send_via_transport(self, address, payload):
         logger.debug('Sending to address: %s', address)
         try:
-            await client.websocket.send(to_client.SerializeToString())
+            await self._clients.get(address).websocket.send(payload)
         except websockets.exceptions.ConnectionClosed:
             logger.info('No connection to address: %s', address)
             return False
 
         return True
-
-    def add_source_consumed(self, source_name):
-        '''Indicate that at least one cognitive engine consumes frames from
-        source_name.
-
-        Must be called before self.launch() or run on the same event loop that
-        self.launch() uses.'''
-
-        if source_name in self._sources_consumed:
-            return
-
-        self._sources_consumed.add(source_name)
-        for client in self._clients.values():
-            client.tokens_for_source[source_name] = self._num_tokens_per_source
-            # TODO inform client about new source
-
-    def remove_source_consumed(self, source_name):
-        '''Indicate that all cognitive engines that consumed frames fome source
-        have stopped.
-
-        Must be called before self.launch() or run on the same event loop that
-        self.launch() uses.'''
-
-        if source_name not in self._sources_consumed:
-            return
-
-        self._sources_consumed.remove(source_name)
-        for client in self._clients.values():
-            del client.tokens_for_source[source_name]
-            # TODO inform client source was removed
 
     def is_running(self):
         if self._server is None:
@@ -134,7 +64,7 @@ class WebsocketServer(ABC):
         address = websocket.remote_address
         logger.info('New Client connected: %s', address)
 
-        client = _Client(
+        client = self._Client(
             tokens_for_source={source_name: self._num_tokens_per_source
                                for source_name in self._sources_consumed},
             websocket=websocket)
@@ -176,21 +106,3 @@ class WebsocketServer(ABC):
             to_client.response.result_wrapper.status = status
             await websocket.send(to_client.SerializeToString())
 
-    async def _consumer_helper(self, client, from_client, address):
-        source_name = from_client.source_name
-        if source_name not in self._sources_consumed:
-            logger.error('No engines consume frames from %s', source_name)
-            return ResultWrapper.Status.NO_ENGINE_FOR_SOURCE
-
-        if client.tokens_for_source[source_name] < 1:
-            logger.error(
-                'Client %s sending from source %s without tokens', address,
-                source_name)
-            return ResultWrapper.Status.NO_TOKENS
-
-        send_success = await self._engine_cb(from_client, address)
-        if send_success:
-            return ResultWrapper.Status.SUCCESS
-        else:
-            logger.error('Server dropped frame from: %s', source_name)
-            return gabriel_pb2.ResultWrapper.Status.SERVER_DROPPED_FRAME

--- a/server/src/gabriel_server/zeromq_server.py
+++ b/server/src/gabriel_server/zeromq_server.py
@@ -174,10 +174,11 @@ class ZeroMQServer(ABC):
             # Listen for client messages
             try:
                 address, raw_input = await socket.recv_multipart()
-            except zmq.ZMQError as error:
+            except (zmq.ZMQError, ValueError) as error:
                 logging.error(
                     f"Error '{error.msg}' when receiving on ZeroMQ socket")
                 continue
+
 
             client = self._clients.get(address)
 

--- a/server/src/gabriel_server/zeromq_server.py
+++ b/server/src/gabriel_server/zeromq_server.py
@@ -1,13 +1,11 @@
 import asyncio
-from collections import namedtuple
 from gabriel_protocol import gabriel_pb2
 from gabriel_protocol.gabriel_pb2 import ResultWrapper
+from gabriel_server import GabrielServer
 import logging
 import zmq
 import zmq.asyncio
-from abc import abstractmethod
-from abc import ABC
-import pdb
+from google.protobuf.message import DecodeError
 
 URI_FORMAT = 'tcp://*:{}'
 
@@ -22,46 +20,15 @@ HELLO_MSG = b'Hello message'
 
 logger = logging.getLogger(__name__)
 
-ctx = zmq.asyncio.Context()
-# The socket used for communicating with all clients
-socket = ctx.socket(zmq.ROUTER)
-
-# Metadata for each client. 'tokens_for_source' is a dictionary that stores
-# the tokens available for each source. 'task' is an async task that consumes
-# inputs from 'inputs' for each client.
-_Client = namedtuple('_Client', ['tokens_for_source', 'inputs', 'task'])
-
-class ZeroMQServer(ABC):
-    """
-    Connects to Gabriel clients using ZeroMQ. Consumes input from the clients
-    and passes it to the specified callback function. Results are sent back to
-    the client as they become available.
-    """
+class ZeroMQServer(GabrielServer):
     def __init__(self, num_tokens_per_source, engine_cb):
-        """
-        Args:
-            num_tokens_per_source (int):
-                The number of tokens available for each source
-            engine_cb:
-                Callback invoked for each input received from a client
-        """
-        self._num_tokens_per_source = num_tokens_per_source
-        # The clients connected to the server
-        self._clients = {}
-        # The sources consumed by the server
-        self._sources_consumed = set()
-        # Indicates that the server start up is finished
-        self._start_event = asyncio.Event()
+        super.__init__(num_tokens_per_source, engine_cb)
         self._is_running = False
-        self._engine_cb = engine_cb
+        self.ctx = zmq.asyncio.Context()
+        # The socket used for communicating with all clients
+        self.sock = self.ctx.socket(zmq.ROUTER)
 
     def launch(self, port, message_max_size):
-        """
-        Launch the server.
-
-        Args:
-            port (int): the port to bind to
-        """
         asyncio.ensure_future(self._launch_helper(port))
         asyncio.get_event_loop().run_forever()
 
@@ -72,90 +39,19 @@ class ZeroMQServer(ABC):
         Args:
             port (int): the port to bind to
         """
-        socket.bind(URI_FORMAT.format(port))
+        self.sock.bind(URI_FORMAT.format(port))
         self._is_running = True
         asyncio.create_task(self._handler())
         self._start_event.set()
         logger.info(f"Listening on {URI_FORMAT.format(port)}")
 
-    async def wait_for_start(self):
-        await self._start_event.wait()
-
-    async def send_result_wrapper(
-            self, address, source_name, frame_id, result_wrapper, return_token):
-        """
-        Send result to client at address.
-
-        Args:
-            address: The identifier of the client to send the result to
-            source_name: The name of the source that the result corresponds to
-            frame_id: The frame id of the input that the result corresponds to
-            result_wrapper: The result payload to send to the client
-            return_token: Whether to return a token to the client
-
-        Returns True if send succeeded.
-        """
-        client = self._clients.get(address)
-        if client is None:
-            logger.warning('Send request to invalid address: %s', address)
-            return False
-
-        if source_name not in client.tokens_for_source:
-            logger.warning('Send request with invalid source: %s', source_name)
-            # Still send so client gets back token
-        elif return_token:
-            client.tokens_for_source[source_name] += 1
-
-        to_client = gabriel_pb2.ToClient()
-        to_client.response.source_name = source_name
-        to_client.response.frame_id = frame_id
-        to_client.response.return_token = return_token
-        to_client.response.result_wrapper.CopyFrom(result_wrapper)
-
+    async def send_via_transport(self,address, payload):
         logger.debug('Sending result to client %s', address)
-        await socket.send_multipart([
+        await self.sock.send_multipart([
             address,
-            to_client.SerializeToString()
+            payload.SerializeToString()
         ])
-
-    def add_source_consumed(self, source_name):
-        """
-        Indicate that at least one cognitive engine consumes frames from
-        source_name.
-
-        Args:
-            source_name (str): The name of the source to add
-
-        Must be called before self.launch() or run on the same event loop that
-        self.launch() uses.
-        """
-
-        if source_name in self._sources_consumed:
-            return
-
-        self._sources_consumed.add(source_name)
-        for client in self._clients.values():
-            client.tokens_for_source[source_name] = self._num_tokens_per_source
-            # TODO inform client about new source
-
-    def remove_source_consumed(self, source_name):
-        """
-        Indicate that all cognitive engines that consumed frames from source
-        have stopped.
-
-        Args:
-            source_name (str): The name of the source to remove
-
-        Must be called before self.launch() or run on the same event loop that
-        self.launch() uses.
-        """
-        if source_name not in self._sources_consumed:
-            return
-
-        self._sources_consumed.remove(source_name)
-        for client in self._clients.values():
-            del client.tokens_for_source[source_name]
-            # TODO inform client source was removed
+        return True
 
     def is_running(self):
         """Returns true if the server is still running."""
@@ -173,7 +69,7 @@ class ZeroMQServer(ABC):
         while self._is_running:
             # Listen for client messages
             try:
-                address, raw_input = await socket.recv_multipart()
+                address, raw_input = await self.sock.recv_multipart()
             except (zmq.ZMQError, ValueError) as error:
                 logging.error(
                     f"Error '{error.msg}' when receiving on ZeroMQ socket")
@@ -185,7 +81,7 @@ class ZeroMQServer(ABC):
             # Register new clients
             if client is None:
                 logger.info('New client connected: %s', address)
-                client = _Client(
+                client = self._Client(
                     tokens_for_source={source_name: self._num_tokens_per_source
                         for source_name in self._sources_consumed},
                     inputs=asyncio.Queue(),
@@ -197,7 +93,7 @@ class ZeroMQServer(ABC):
                 for source_name in self._sources_consumed:
                     to_client.welcome.sources_consumed.append(source_name)
                 to_client.welcome.num_tokens_per_source = self._num_tokens_per_source
-                await socket.send_multipart([
+                await self.sock.send_multipart([
                     address,
                     to_client.SerializeToString()
                 ])
@@ -238,7 +134,7 @@ class ZeroMQServer(ABC):
 
             # Received heartbeat, send back heartbeat
             if raw_input == HEARTBEAT:
-                socket.send_multipart([
+                self.sock.send_multipart([
                     address,
                     HEARTBEAT
                 ])
@@ -266,36 +162,7 @@ class ZeroMQServer(ABC):
             to_client.response.frame_id = from_client.frame_id
             to_client.response.return_token = True
             to_client.response.result_wrapper.status = status
-            await socket.send_multipart([
+            await self.sock.send_multipart([
                 address,
                 to_client.SerializeToString()
             ])
-
-    async def _consumer_helper(self, client, address, from_client):
-        """
-        Send the input to the engine callback.
-
-        Args:
-            client: The client that the input is from
-            address: The identifier of the client
-            from_client: A FromClient protobuf message containing the input
-        """
-        source_name = from_client.source_name
-        if source_name not in self._sources_consumed:
-            logger.error('No engines consume frames from %s', source_name)
-            return ResultWrapper.Status.NO_ENGINE_FOR_SOURCE
-
-        if client.tokens_for_source[source_name] < 1:
-            logger.error(
-                'Client %s sending from source %s without tokens', address,
-                source_name)
-            return ResultWrapper.Status.NO_TOKENS
-
-        logging.debug(f"Sending input from client {address} to engine")
-        send_success = await self._engine_cb(from_client, address)
-        if send_success:
-            return ResultWrapper.Status.SUCCESS
-        else:
-            logger.error('Server dropped frame from: %s', source_name)
-            return gabriel_pb2.ResultWrapper.Status.SERVER_DROPPED_FRAME
-

--- a/server/src/gabriel_server/zeromq_server.py
+++ b/server/src/gabriel_server/zeromq_server.py
@@ -9,7 +9,7 @@ from abc import abstractmethod
 from abc import ABC
 import pdb
 
-URI_FORMAT = 'tcp://127.0.0.1:{}'
+URI_FORMAT = 'tcp://*:{}'
 CLIENT_TIMEOUT_SECS = 10
 
 logger = logging.getLogger(__name__)

--- a/server/src/gabriel_server/zeromq_server.py
+++ b/server/src/gabriel_server/zeromq_server.py
@@ -1,0 +1,199 @@
+import asyncio
+from collections import namedtuple
+from gabriel_protocol import gabriel_pb2
+from gabriel_protocol.gabriel_pb2 import ResultWrapper
+import logging
+import zmq
+import zmq.asyncio
+
+URI_FORMAT = 'tcp://*:{}'
+CLIENT_TIMEOUT_SECS = 10
+
+logger = logging.getLogger(__name__)
+
+ctx = zmq.asyncio.Context()
+socket = ctx.socket(zmq.ROUTER)
+
+_Client = namedtuple('_Client', ['tokens_for_source', 'work_queue'])
+
+class ZeroMQServer:
+    def __init__(self, num_tokens_per_source):
+        self._num_tokens_per_source = num_tokens_per_source
+        self._clients = {}
+        self._sources_consumed = set()
+        self._start_event = asyncio.Event()
+        self._work_queue = asyncio.Queue()
+        self._is_running = False
+
+    @abstractmethod
+    async def _send_to_engine(self, from_client, address):
+        '''Send FromClient to the appropriate engine(s).
+
+        Return True if send succeeded.'''
+        pass
+
+    def launch(self, port):
+        socket.bind(URI_FORMAT.format(port))
+        self._is_running = True
+        asyncio.create_task(_handler())
+        self._start_event.set()
+
+    async def wait_for_start(self):
+        await self._start_event.wait()
+
+    async def send_result_wrapper(
+            self, address, source_name, frame_id, result_wrapper, return_token):
+        '''Send result to client at address.
+
+        Returns True if send succeeded.'''
+
+        client = self._clients.get(address)
+        if client is None:
+            logger.warning('Send request to invalid address: %s', address)
+            return False
+
+        if source_name not in client.tokens_for_source:
+            logger.warning('Send request with invalid source: %s', source_name)
+            # Still send so client gets back token
+        elif return_token:
+            client.tokens_for_source[source_name] += 1
+
+        to_client = gabriel_pb2.ToClient()
+        to_client.response.source_name = source_name
+        to_client.response.frame_id = frame_id
+        to_client.response.return_token = return_token
+        to_client.response.result_wrapper.CopyFrom(result_wrapper)
+
+        logger.debug('Sending to address: %s', address)
+        await socket.send_multipart([
+            address,
+            b'',
+            to_client.SerializeToString()
+        ])
+
+    def add_source_consumed(self, source_name):
+        '''Indicate that at least one cognitive engine consumes frames from
+        source_name.
+
+        Must be called before self.launch() or run on the same event loop that
+        self.launch() uses.'''
+
+        if source_name in self._sources_consumed:
+            return
+
+        self._sources_consumed.add(source_name)
+        for client in self._clients.values():
+            client.tokens_for_source[source_name] = self._num_tokens_per_source
+            # TODO inform client about new source
+
+    def remove_source_consumed(self, source_name):
+        '''Indicate that all cognitive engines that consumed frames from source
+        have stopped.
+
+        Must be called before self.launch() or run on the same event loop that
+        self.launch() uses.'''
+
+        if source_name not in self._sources_consumed:
+            return
+
+        self._sources_consumed.remove(source_name)
+        for client in self._clients.values():
+            del client.tokens_for_source[source_name]
+            # TODO inform client source was removed
+
+    def is_running(self):
+        return self._is_running
+
+    async def _handler(self):
+        while self._is_running:
+            # Listen for client messages
+            try:
+                address, empty, raw_input = await socket.recv_multipart()
+            except zmq.ZMQError as error:
+                logging.error(f"Error '{error.msg}' when receiving on ZeroMQ socket")
+                continue
+
+            client = self._clients.get(address)
+
+            # Register new clients
+            if client is None:
+                logger.info('New client connected: %s', address)
+                client = _Client(
+                    tokens_for_source={source_name: self._num_tokens_per_source
+                        for source_name in self._sources_consumed},
+                    inputs=asyncio.Queue(),
+                    task=None)
+                self._clients[address] = client
+                client.task = asyncio.create_task(_consumer(address))
+
+                # Send client welcome message
+                to_client = gabriel_pb2.ToClient()
+                for source_name in self._sources_consumed:
+                    to_client.welcome.sources_consumed.append(source_name)
+                to_client.welcome.num_tokens_per_source = self._num_tokens_per_source
+                await socket.send_multipart([
+                    address,
+                    b'',
+                    to_client.SerializeToString()
+                ])
+
+            # Handle input
+            logger.debug('Received input from %s', address)
+            await client.inputs.put(raw_input)
+
+    async def _consumer(self, address):
+        client = self._clients.get(address)
+        if client is None:
+            logging.debug(f"Client {address} not registered")
+            return
+
+        while address in self._clients:
+            try:
+                raw_input = asyncio.wait_for(client.inputs.get(), CLIENT_TIMEOUT_SECS)
+            except TimeoutError:
+                logger.info(f"Client disconnected: {address}")
+                del self._clients[address]
+                return
+
+            logger.debug('Consuming input from %s', address)
+
+            from_client = gabriel_pb2.FromClient()
+            from_client.ParseFromString(raw_input)
+
+            status = await self._consumer_helper(client, address, from_client)
+
+            if status == ResultWrapper.Status.SUCCESS:
+                client.tokens_for_source[from_client.source_name] -= 1
+                return
+
+            # Send error message
+            to_client = gabriel_pb2.ToClient()
+            to_client.response.source_name = from_client.source_name
+            to_client.response.frame_id = from_client.frame_id
+            to_client.response.return_token = True
+            to_client.response.result_wrapper.status = status
+            await socket.send_multipart([
+                address,
+                b'',
+                to_client.SerializeToString()
+            ])
+
+    async def _consumer_helper(self, client, address, from_client):
+        source_name = from_client.source_name
+        if source_name not in self._sources_consumed:
+            logger.error('No engines consume frames from %s', source_name)
+            return ResultWrapper.Status.NO_ENGINE_FOR_SOURCE
+
+        if client.tokens_for_source[source_name] < 1:
+            logger.error(
+                'Client %s sending from source %s without tokens', address,
+                source_name)
+            return ResultWrapper.Status.NO_TOKENS
+
+        send_success = await self._send_to_engine(from_client, address)
+        if send_success:
+            return ResultWrapper.Status.SUCCESS
+        else:
+            logger.error('Server dropped frame from: %s', source_name)
+            return gabriel_pb2.ResultWrapper.Status.SERVER_DROPPED_FRAME
+

--- a/server/src/gabriel_server/zeromq_server.py
+++ b/server/src/gabriel_server/zeromq_server.py
@@ -137,7 +137,7 @@ class ZeroMQServer(GabrielServer):
             # Received heartbeat, send back heartbeat
             if raw_input == HEARTBEAT:
                 logger.debug(f"Received heartbeat from client {address}; sending back heartbeat")
-                self.sock.send_multipart([
+                await self.sock.send_multipart([
                     address,
                     HEARTBEAT
                 ])

--- a/server/src/gabriel_server/zeromq_server.py
+++ b/server/src/gabriel_server/zeromq_server.py
@@ -129,7 +129,7 @@ class ZeroMQServer(GabrielServer):
         while address in self._clients:
             try:
                 raw_input = await asyncio.wait_for(client.inputs.get(), CLIENT_TIMEOUT_SECS)
-            except TimeoutError:
+            except (TimeoutError, asyncio.TimeoutError):
                 logger.info(f"Client disconnected: {address}")
                 del self._clients[address]
                 return

--- a/server/src/gabriel_server/zeromq_server.py
+++ b/server/src/gabriel_server/zeromq_server.py
@@ -17,6 +17,9 @@ CLIENT_TIMEOUT_SECS = 10
 # Message used to check connectivity between the client and the server
 HEARTBEAT = b''
 
+# Message sent by the client to register with the server
+HELLO_MSG = b'Hello message'
+
 logger = logging.getLogger(__name__)
 
 ctx = zmq.asyncio.Context()
@@ -43,10 +46,12 @@ class ZeroMQServer(ABC):
                 Callback invoked for each input received from a client
         """
         self._num_tokens_per_source = num_tokens_per_source
+        # The clients connected to the server
         self._clients = {}
+        # The sources consumed by the server
         self._sources_consumed = set()
+        # Indicates that the server start up is finished
         self._start_event = asyncio.Event()
-        self._stop_event = asyncio.Event()
         self._is_running = False
         self._engine_cb = engine_cb
 
@@ -197,7 +202,7 @@ class ZeroMQServer(ABC):
                 ])
                 logger.debug('Sent welcome message to new client: %s', address)
 
-            if raw_input == b'Hello message':
+            if raw_input == HELLO_MSG:
                 continue
 
             # Handle input

--- a/server/src/gabriel_server/zeromq_server.py
+++ b/server/src/gabriel_server/zeromq_server.py
@@ -135,6 +135,7 @@ class ZeroMQServer(GabrielServer):
 
             # Received heartbeat, send back heartbeat
             if raw_input == HEARTBEAT:
+                logger.debug(f"Received heartbeat from client {address}; sending back heartbeat")
                 self.sock.send_multipart([
                     address,
                     HEARTBEAT

--- a/server/src/gabriel_server/zeromq_server.py
+++ b/server/src/gabriel_server/zeromq_server.py
@@ -91,6 +91,7 @@ class ZeroMQServer(GabrielServer):
 
                 # Send client welcome message
                 to_client = gabriel_pb2.ToClient()
+                logger.debug(f"{len(self._sources_consumed)} source(s) available for consumption")
                 for source_name in self._sources_consumed:
                     to_client.welcome.sources_consumed.append(source_name)
                 to_client.welcome.num_tokens_per_source = self._num_tokens_per_source

--- a/server/src/gabriel_server/zeromq_server.py
+++ b/server/src/gabriel_server/zeromq_server.py
@@ -10,17 +10,38 @@ from abc import ABC
 import pdb
 
 URI_FORMAT = 'tcp://*:{}'
+
+# The duration of time after which a client is considered disconnected
 CLIENT_TIMEOUT_SECS = 10
+
+# Message used to check connectivity between the client and the server
+HEARTBEAT = b''
 
 logger = logging.getLogger(__name__)
 
 ctx = zmq.asyncio.Context()
+# The socket used for communicating with all clients
 socket = ctx.socket(zmq.ROUTER)
 
+# Metadata for each client. 'tokens_for_source' is a dictionary that stores
+# the tokens available for each source. 'task' is an async task that consumes
+# inputs from 'inputs' for each client.
 _Client = namedtuple('_Client', ['tokens_for_source', 'inputs', 'task'])
 
 class ZeroMQServer(ABC):
+    """
+    Connects to Gabriel clients using ZeroMQ. Consumes input from the clients
+    and passes it to the specified callback function. Results are sent back to
+    the client as they become available.
+    """
     def __init__(self, num_tokens_per_source, engine_cb):
+        """
+        Args:
+            num_tokens_per_source (int):
+                The number of tokens available for each source
+            engine_cb:
+                Callback invoked for each input received from a client
+        """
         self._num_tokens_per_source = num_tokens_per_source
         self._clients = {}
         self._sources_consumed = set()
@@ -30,10 +51,22 @@ class ZeroMQServer(ABC):
         self._engine_cb = engine_cb
 
     def launch(self, port, message_max_size):
-        asyncio.ensure_future(self.launch_helper(port))
+        """
+        Launch the server.
+
+        Args:
+            port (int): the port to bind to
+        """
+        asyncio.ensure_future(self._launch_helper(port))
         asyncio.get_event_loop().run_forever()
 
-    async def launch_helper(self, port):
+    async def _launch_helper(self, port):
+        """
+        Bind to the specified port and launch the client handler.
+
+        Args:
+            port (int): the port to bind to
+        """
         socket.bind(URI_FORMAT.format(port))
         self._is_running = True
         asyncio.create_task(self._handler())
@@ -45,10 +78,18 @@ class ZeroMQServer(ABC):
 
     async def send_result_wrapper(
             self, address, source_name, frame_id, result_wrapper, return_token):
-        '''Send result to client at address.
+        """
+        Send result to client at address.
 
-        Returns True if send succeeded.'''
+        Args:
+            address: The identifier of the client to send the result to
+            source_name: The name of the source that the result corresponds to
+            frame_id: The frame id of the input that the result corresponds to
+            result_wrapper: The result payload to send to the client
+            return_token: Whether to return a token to the client
 
+        Returns True if send succeeded.
+        """
         client = self._clients.get(address)
         if client is None:
             logger.warning('Send request to invalid address: %s', address)
@@ -73,11 +114,16 @@ class ZeroMQServer(ABC):
         ])
 
     def add_source_consumed(self, source_name):
-        '''Indicate that at least one cognitive engine consumes frames from
+        """
+        Indicate that at least one cognitive engine consumes frames from
         source_name.
 
+        Args:
+            source_name (str): The name of the source to add
+
         Must be called before self.launch() or run on the same event loop that
-        self.launch() uses.'''
+        self.launch() uses.
+        """
 
         if source_name in self._sources_consumed:
             return
@@ -88,12 +134,16 @@ class ZeroMQServer(ABC):
             # TODO inform client about new source
 
     def remove_source_consumed(self, source_name):
-        '''Indicate that all cognitive engines that consumed frames from source
+        """
+        Indicate that all cognitive engines that consumed frames from source
         have stopped.
 
-        Must be called before self.launch() or run on the same event loop that
-        self.launch() uses.'''
+        Args:
+            source_name (str): The name of the source to remove
 
+        Must be called before self.launch() or run on the same event loop that
+        self.launch() uses.
+        """
         if source_name not in self._sources_consumed:
             return
 
@@ -103,15 +153,25 @@ class ZeroMQServer(ABC):
             # TODO inform client source was removed
 
     def is_running(self):
+        """Returns true if the server is still running."""
         return self._is_running
 
     async def _handler(self):
+        """
+        Handles incoming client messages.
+
+        When a new client is connected it is registered and a welcome message
+        is sent to the client, indicating that the server is ready to start
+        receiving inputs from the client. For each client, keeps track of the
+        number of tokens available for each source.
+        """
         while self._is_running:
             # Listen for client messages
             try:
                 address, raw_input = await socket.recv_multipart()
             except zmq.ZMQError as error:
-                logging.error(f"Error '{error.msg}' when receiving on ZeroMQ socket")
+                logging.error(
+                    f"Error '{error.msg}' when receiving on ZeroMQ socket")
                 continue
 
             client = self._clients.get(address)
@@ -141,21 +201,27 @@ class ZeroMQServer(ABC):
                 continue
 
             # Handle input
-            if raw_input == b'':
+            if raw_input == HEARTBEAT:
                 logger.debug(f'Received heartbeat from client {address}')
             else:
                 logger.debug('Received input from %s', address)
+            # Push input to the queue of inputs for this client
             client.inputs.put_nowait(raw_input)
 
-        logger.debug("Done running handler")
-
     async def _consumer(self, address):
+        """
+        Consumes client inputs. Sends an error message to the client on failure.
+
+        Args:
+            address: the identifier of the client to consume inputs for
+        """
         client = self._clients.get(address)
         if client is None:
             logging.debug(f"Client {address} not registered")
             return
         logging.debug(f"Consuming inputs for client {address}")
 
+        # Consume inputs for this client as long as it is registered
         while address in self._clients:
             try:
                 raw_input = await asyncio.wait_for(client.inputs.get(), CLIENT_TIMEOUT_SECS)
@@ -165,10 +231,10 @@ class ZeroMQServer(ABC):
                 return
 
             # Received heartbeat, send back heartbeat
-            if raw_input == b'':
+            if raw_input == HEARTBEAT:
                 socket.send_multipart([
                     address,
-                    b''
+                    HEARTBEAT
                 ])
                 continue
 
@@ -179,6 +245,7 @@ class ZeroMQServer(ABC):
                 logger.error(f"Failed to parse input from client {address}: {e}")
                 continue
 
+            # Consume input
             status = await self._consumer_helper(client, address, from_client)
 
             if status == ResultWrapper.Status.SUCCESS:
@@ -199,6 +266,14 @@ class ZeroMQServer(ABC):
             ])
 
     async def _consumer_helper(self, client, address, from_client):
+        """
+        Send the input to the engine callback.
+
+        Args:
+            client: The client that the input is from
+            address: The identifier of the client
+            from_client: A FromClient protobuf message containing the input
+        """
         source_name = from_client.source_name
         if source_name not in self._sources_consumed:
             logger.error('No engines consume frames from %s', source_name)

--- a/server/src/gabriel_server/zeromq_server.py
+++ b/server/src/gabriel_server/zeromq_server.py
@@ -41,7 +41,7 @@ class ZeroMQServer(GabrielServer):
         """
         self.sock.bind(URI_FORMAT.format(port))
         self._is_running = True
-        asyncio.create_task(self._handler())
+        self._handler_task = asyncio.create_task(self._handler())
         self._start_event.set()
         logger.info(f"Listening on {URI_FORMAT.format(port)}")
 
@@ -121,9 +121,9 @@ class ZeroMQServer(GabrielServer):
         """
         client = self._clients.get(address)
         if client is None:
-            logging.debug(f"Client {address} not registered")
+            logger.debug(f"Client {address} not registered")
             return
-        logging.debug(f"Consuming inputs for client {address}")
+        logger.debug(f"Consuming inputs for client {address}")
 
         # Consume inputs for this client as long as it is registered
         while address in self._clients:
@@ -154,12 +154,12 @@ class ZeroMQServer(GabrielServer):
             status = await self._consumer_helper(client, address, from_client)
 
             if status == ResultWrapper.Status.SUCCESS:
-                logging.debug("Consumed input from %s successfully", address)
+                logger.debug("Consumed input from %s successfully", address)
                 client.tokens_for_source[from_client.source_name] -= 1
                 continue
 
             # Send error message
-            logging.debug(f"Sending error message to client {address}")
+            logger.debug(f"Sending error message to client {address}")
             to_client = gabriel_pb2.ToClient()
             to_client.response.source_name = from_client.source_name
             to_client.response.frame_id = from_client.frame_id


### PR DESCRIPTION
The Gabriel client currently uses WebSockets to communicate with the server. That means that currently we do not have support for attempting re-connection when disconnected temporarily. Switching to ZeroMQ allows us to attempt re-connection, and will also make it so that our entire stack uses ZeroMQ—ZeroMQ is currently used to communicate between the cognitive engines and the Gabriel server.