### PR TITLE
Invert the client-engine subscription model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ local.properties
 .externalNativeBuild
 .cxx
 *~
+
+*swp

--- a/protocol/protos/gabriel.proto
+++ b/protocol/protos/gabriel.proto
@@ -79,16 +79,17 @@ message ResultWrapper {
 message ToClient {
     message Welcome {
         repeated string computations_supported = 1;
-        int32 num_tokens_per_source = 2;
+        int32 num_tokens_per_bucket = 2;
     }
 
     message Response {
-        // The computation type that the response corresponds to; allows the
+        // The token bucket that the response corresponds to; allows the
         // client to return the tokens correctly.
-        string computation_type = 1;
+        string token_bucket = 1;
         int64 frame_id = 2;
         bool return_token = 3;
         ResultWrapper result_wrapper = 4;
+        string computation_type = 5;
     }
 
     oneof welcome_or_response {

--- a/protocol/protos/gabriel.proto
+++ b/protocol/protos/gabriel.proto
@@ -26,8 +26,9 @@ message InputFrame {
 
 message FromClient {
     int64 frame_id = 1;
-    string source_name = 2;
+    string token_bucket = 2;
     InputFrame input_frame = 3;
+    repeated string target_computation_types = 4;
 }
 
 message ResultWrapper {
@@ -42,8 +43,8 @@ message ResultWrapper {
         // Cognitive engine expected different PayloadType from this source
         WRONG_INPUT_FORMAT = 3;
 
-        // No Cognitive engines accept frames from source_name
-        NO_ENGINE_FOR_SOURCE = 4;
+        // No cognitive engines perform the requested computation.
+        NO_ENGINE_FOR_COMPUTATION = 4;
 
         // This client has no tokens to send frames from source_name
         NO_TOKENS = 5;
@@ -77,14 +78,14 @@ message ResultWrapper {
 
 message ToClient {
     message Welcome {
-        repeated string sources_consumed = 1;
+        repeated string computations_supported = 1;
         int32 num_tokens_per_source = 2;
     }
 
     message Response {
-        // The source of the original frame; allows the client to return the
-        // token correctly.
-        string source_name = 1;
+        // The computation type that the response corresponds to; allows the
+        // client to return the tokens correctly.
+        string computation_type = 1;
         int64 frame_id = 2;
         bool return_token = 3;
         ResultWrapper result_wrapper = 4;
@@ -98,8 +99,9 @@ message ToClient {
 
 message FromStandaloneEngine {
     message Welcome {
-        string source_name = 1;
+        string computation_type = 1;
         bool all_responses_required = 2;
+        string engine_name = 3;
     }
 
     oneof welcome_or_result_wrapper {

--- a/protocol/python/src/gabriel_protocol/gabriel_pb2.py
+++ b/protocol/python/src/gabriel_protocol/gabriel_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import any_pb2 as google_dot_protobuf_dot_any__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rgabriel.proto\x12\x07gabriel\x1a\x19google/protobuf/any.proto\"p\n\nInputFrame\x12*\n\x0cpayload_type\x18\x01 \x01(\x0e\x32\x14.gabriel.PayloadType\x12\x10\n\x08payloads\x18\x02 \x03(\x0c\x12$\n\x06\x65xtras\x18\x03 \x01(\x0b\x32\x14.google.protobuf.Any\"\x7f\n\nFromClient\x12\x10\n\x08\x66rame_id\x18\x01 \x01(\x03\x12\x13\n\x0bsource_name\x18\x02 \x01(\t\x12(\n\x0binput_frame\x18\x03 \x01(\x0b\x32\x13.gabriel.InputFrame\x12 \n\x18target_computation_types\x18\x04 \x03(\t\"\xdc\x03\n\rResultWrapper\x12-\n\x06status\x18\x01 \x01(\x0e\x32\x1d.gabriel.ResultWrapper.Status\x12.\n\x07results\x18\x02 \x03(\x0b\x32\x1d.gabriel.ResultWrapper.Result\x12$\n\x06\x65xtras\x18\x03 \x01(\x0b\x32\x14.google.protobuf.Any\x12@\n\x14result_producer_name\x18\x04 \x01(\x0b\x32\".gabriel.ResultWrapper.StringValue\x1a\x45\n\x06Result\x12*\n\x0cpayload_type\x18\x01 \x01(\x0e\x32\x14.gabriel.PayloadType\x12\x0f\n\x07payload\x18\x02 \x01(\x0c\x1a\x1c\n\x0bStringValue\x12\r\n\x05value\x18\x01 \x01(\t\"\x9e\x01\n\x06Status\x12\x0b\n\x07SUCCESS\x10\x00\x12\x15\n\x11UNSPECIFIED_ERROR\x10\x01\x12\x10\n\x0c\x45NGINE_ERROR\x10\x02\x12\x16\n\x12WRONG_INPUT_FORMAT\x10\x03\x12\x1d\n\x19NO_ENGINE_FOR_COMPUTATION\x10\x04\x12\r\n\tNO_TOKENS\x10\x05\x12\x18\n\x14SERVER_DROPPED_FRAME\x10\x06\"\xc7\x02\n\x08ToClient\x12,\n\x07welcome\x18\x01 \x01(\x0b\x32\x19.gabriel.ToClient.WelcomeH\x00\x12.\n\x08response\x18\x02 \x01(\x0b\x32\x1a.gabriel.ToClient.ResponseH\x00\x1aH\n\x07Welcome\x12\x1e\n\x16\x63omputations_supported\x18\x01 \x03(\t\x12\x1d\n\x15num_tokens_per_source\x18\x02 \x01(\x05\x1a|\n\x08Response\x12\x18\n\x10\x63omputation_type\x18\x01 \x01(\t\x12\x10\n\x08\x66rame_id\x18\x02 \x01(\x03\x12\x14\n\x0creturn_token\x18\x03 \x01(\x08\x12.\n\x0eresult_wrapper\x18\x04 \x01(\x0b\x32\x16.gabriel.ResultWrapperB\x15\n\x13welcome_or_response\"\xf9\x01\n\x14\x46romStandaloneEngine\x12\x38\n\x07welcome\x18\x01 \x01(\x0b\x32%.gabriel.FromStandaloneEngine.WelcomeH\x00\x12\x30\n\x0eresult_wrapper\x18\x02 \x01(\x0b\x32\x16.gabriel.ResultWrapperH\x00\x1aX\n\x07Welcome\x12\x18\n\x10\x63omputation_type\x18\x01 \x01(\t\x12\x1e\n\x16\x61ll_responses_required\x18\x02 \x01(\x08\x12\x13\n\x0b\x65ngine_name\x18\x03 \x01(\tB\x1b\n\x19welcome_or_result_wrapper*[\n\x0bPayloadType\x12\t\n\x05IMAGE\x10\x00\x12\t\n\x05VIDEO\x10\x01\x12\t\n\x05\x41UDIO\x10\x02\x12\x07\n\x03IMU\x10\x03\x12\x08\n\x04TEXT\x10\x04\x12\r\n\tANIMATION\x10\x05\x12\t\n\x05OTHER\x10\x06\x42%\n\x1b\x65\x64u.cmu.cs.gabriel.protocolB\x06Protosb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rgabriel.proto\x12\x07gabriel\x1a\x19google/protobuf/any.proto\"p\n\nInputFrame\x12*\n\x0cpayload_type\x18\x01 \x01(\x0e\x32\x14.gabriel.PayloadType\x12\x10\n\x08payloads\x18\x02 \x03(\x0c\x12$\n\x06\x65xtras\x18\x03 \x01(\x0b\x32\x14.google.protobuf.Any\"\x80\x01\n\nFromClient\x12\x10\n\x08\x66rame_id\x18\x01 \x01(\x03\x12\x14\n\x0ctoken_bucket\x18\x02 \x01(\t\x12(\n\x0binput_frame\x18\x03 \x01(\x0b\x32\x13.gabriel.InputFrame\x12 \n\x18target_computation_types\x18\x04 \x03(\t\"\xdc\x03\n\rResultWrapper\x12-\n\x06status\x18\x01 \x01(\x0e\x32\x1d.gabriel.ResultWrapper.Status\x12.\n\x07results\x18\x02 \x03(\x0b\x32\x1d.gabriel.ResultWrapper.Result\x12$\n\x06\x65xtras\x18\x03 \x01(\x0b\x32\x14.google.protobuf.Any\x12@\n\x14result_producer_name\x18\x04 \x01(\x0b\x32\".gabriel.ResultWrapper.StringValue\x1a\x45\n\x06Result\x12*\n\x0cpayload_type\x18\x01 \x01(\x0e\x32\x14.gabriel.PayloadType\x12\x0f\n\x07payload\x18\x02 \x01(\x0c\x1a\x1c\n\x0bStringValue\x12\r\n\x05value\x18\x01 \x01(\t\"\x9e\x01\n\x06Status\x12\x0b\n\x07SUCCESS\x10\x00\x12\x15\n\x11UNSPECIFIED_ERROR\x10\x01\x12\x10\n\x0c\x45NGINE_ERROR\x10\x02\x12\x16\n\x12WRONG_INPUT_FORMAT\x10\x03\x12\x1d\n\x19NO_ENGINE_FOR_COMPUTATION\x10\x04\x12\r\n\tNO_TOKENS\x10\x05\x12\x18\n\x14SERVER_DROPPED_FRAME\x10\x06\"\xde\x02\n\x08ToClient\x12,\n\x07welcome\x18\x01 \x01(\x0b\x32\x19.gabriel.ToClient.WelcomeH\x00\x12.\n\x08response\x18\x02 \x01(\x0b\x32\x1a.gabriel.ToClient.ResponseH\x00\x1aH\n\x07Welcome\x12\x1e\n\x16\x63omputations_supported\x18\x01 \x03(\t\x12\x1d\n\x15num_tokens_per_bucket\x18\x02 \x01(\x05\x1a\x92\x01\n\x08Response\x12\x14\n\x0ctoken_bucket\x18\x01 \x01(\t\x12\x10\n\x08\x66rame_id\x18\x02 \x01(\x03\x12\x14\n\x0creturn_token\x18\x03 \x01(\x08\x12.\n\x0eresult_wrapper\x18\x04 \x01(\x0b\x32\x16.gabriel.ResultWrapper\x12\x18\n\x10\x63omputation_type\x18\x05 \x01(\tB\x15\n\x13welcome_or_response\"\xf9\x01\n\x14\x46romStandaloneEngine\x12\x38\n\x07welcome\x18\x01 \x01(\x0b\x32%.gabriel.FromStandaloneEngine.WelcomeH\x00\x12\x30\n\x0eresult_wrapper\x18\x02 \x01(\x0b\x32\x16.gabriel.ResultWrapperH\x00\x1aX\n\x07Welcome\x12\x18\n\x10\x63omputation_type\x18\x01 \x01(\t\x12\x1e\n\x16\x61ll_responses_required\x18\x02 \x01(\x08\x12\x13\n\x0b\x65ngine_name\x18\x03 \x01(\tB\x1b\n\x19welcome_or_result_wrapper*[\n\x0bPayloadType\x12\t\n\x05IMAGE\x10\x00\x12\t\n\x05VIDEO\x10\x01\x12\t\n\x05\x41UDIO\x10\x02\x12\x07\n\x03IMU\x10\x03\x12\x08\n\x04TEXT\x10\x04\x12\r\n\tANIMATION\x10\x05\x12\t\n\x05OTHER\x10\x06\x42%\n\x1b\x65\x64u.cmu.cs.gabriel.protocolB\x06Protosb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,28 +33,28 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'gabriel_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'\n\033edu.cmu.cs.gabriel.protocolB\006Protos'
-  _globals['_PAYLOADTYPE']._serialized_start=1357
-  _globals['_PAYLOADTYPE']._serialized_end=1448
+  _globals['_PAYLOADTYPE']._serialized_start=1382
+  _globals['_PAYLOADTYPE']._serialized_end=1473
   _globals['_INPUTFRAME']._serialized_start=53
   _globals['_INPUTFRAME']._serialized_end=165
-  _globals['_FROMCLIENT']._serialized_start=167
-  _globals['_FROMCLIENT']._serialized_end=294
-  _globals['_RESULTWRAPPER']._serialized_start=297
-  _globals['_RESULTWRAPPER']._serialized_end=773
-  _globals['_RESULTWRAPPER_RESULT']._serialized_start=513
-  _globals['_RESULTWRAPPER_RESULT']._serialized_end=582
-  _globals['_RESULTWRAPPER_STRINGVALUE']._serialized_start=584
-  _globals['_RESULTWRAPPER_STRINGVALUE']._serialized_end=612
-  _globals['_RESULTWRAPPER_STATUS']._serialized_start=615
-  _globals['_RESULTWRAPPER_STATUS']._serialized_end=773
-  _globals['_TOCLIENT']._serialized_start=776
-  _globals['_TOCLIENT']._serialized_end=1103
-  _globals['_TOCLIENT_WELCOME']._serialized_start=882
-  _globals['_TOCLIENT_WELCOME']._serialized_end=954
-  _globals['_TOCLIENT_RESPONSE']._serialized_start=956
-  _globals['_TOCLIENT_RESPONSE']._serialized_end=1080
-  _globals['_FROMSTANDALONEENGINE']._serialized_start=1106
-  _globals['_FROMSTANDALONEENGINE']._serialized_end=1355
-  _globals['_FROMSTANDALONEENGINE_WELCOME']._serialized_start=1238
-  _globals['_FROMSTANDALONEENGINE_WELCOME']._serialized_end=1326
+  _globals['_FROMCLIENT']._serialized_start=168
+  _globals['_FROMCLIENT']._serialized_end=296
+  _globals['_RESULTWRAPPER']._serialized_start=299
+  _globals['_RESULTWRAPPER']._serialized_end=775
+  _globals['_RESULTWRAPPER_RESULT']._serialized_start=515
+  _globals['_RESULTWRAPPER_RESULT']._serialized_end=584
+  _globals['_RESULTWRAPPER_STRINGVALUE']._serialized_start=586
+  _globals['_RESULTWRAPPER_STRINGVALUE']._serialized_end=614
+  _globals['_RESULTWRAPPER_STATUS']._serialized_start=617
+  _globals['_RESULTWRAPPER_STATUS']._serialized_end=775
+  _globals['_TOCLIENT']._serialized_start=778
+  _globals['_TOCLIENT']._serialized_end=1128
+  _globals['_TOCLIENT_WELCOME']._serialized_start=884
+  _globals['_TOCLIENT_WELCOME']._serialized_end=956
+  _globals['_TOCLIENT_RESPONSE']._serialized_start=959
+  _globals['_TOCLIENT_RESPONSE']._serialized_end=1105
+  _globals['_FROMSTANDALONEENGINE']._serialized_start=1131
+  _globals['_FROMSTANDALONEENGINE']._serialized_end=1380
+  _globals['_FROMSTANDALONEENGINE_WELCOME']._serialized_start=1263
+  _globals['_FROMSTANDALONEENGINE_WELCOME']._serialized_end=1351
 # @@protoc_insertion_point(module_scope)

--- a/protocol/python/src/gabriel_protocol/gabriel_pb2.py
+++ b/protocol/python/src/gabriel_protocol/gabriel_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import any_pb2 as google_dot_protobuf_dot_any__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rgabriel.proto\x12\x07gabriel\x1a\x19google/protobuf/any.proto\"p\n\nInputFrame\x12*\n\x0cpayload_type\x18\x01 \x01(\x0e\x32\x14.gabriel.PayloadType\x12\x10\n\x08payloads\x18\x02 \x03(\x0c\x12$\n\x06\x65xtras\x18\x03 \x01(\x0b\x32\x14.google.protobuf.Any\"]\n\nFromClient\x12\x10\n\x08\x66rame_id\x18\x01 \x01(\x03\x12\x13\n\x0bsource_name\x18\x02 \x01(\t\x12(\n\x0binput_frame\x18\x03 \x01(\x0b\x32\x13.gabriel.InputFrame\"\xd7\x03\n\rResultWrapper\x12-\n\x06status\x18\x01 \x01(\x0e\x32\x1d.gabriel.ResultWrapper.Status\x12.\n\x07results\x18\x02 \x03(\x0b\x32\x1d.gabriel.ResultWrapper.Result\x12$\n\x06\x65xtras\x18\x03 \x01(\x0b\x32\x14.google.protobuf.Any\x12@\n\x14result_producer_name\x18\x04 \x01(\x0b\x32\".gabriel.ResultWrapper.StringValue\x1a\x45\n\x06Result\x12*\n\x0cpayload_type\x18\x01 \x01(\x0e\x32\x14.gabriel.PayloadType\x12\x0f\n\x07payload\x18\x02 \x01(\x0c\x1a\x1c\n\x0bStringValue\x12\r\n\x05value\x18\x01 \x01(\t\"\x99\x01\n\x06Status\x12\x0b\n\x07SUCCESS\x10\x00\x12\x15\n\x11UNSPECIFIED_ERROR\x10\x01\x12\x10\n\x0c\x45NGINE_ERROR\x10\x02\x12\x16\n\x12WRONG_INPUT_FORMAT\x10\x03\x12\x18\n\x14NO_ENGINE_FOR_SOURCE\x10\x04\x12\r\n\tNO_TOKENS\x10\x05\x12\x18\n\x14SERVER_DROPPED_FRAME\x10\x06\"\xbc\x02\n\x08ToClient\x12,\n\x07welcome\x18\x01 \x01(\x0b\x32\x19.gabriel.ToClient.WelcomeH\x00\x12.\n\x08response\x18\x02 \x01(\x0b\x32\x1a.gabriel.ToClient.ResponseH\x00\x1a\x42\n\x07Welcome\x12\x18\n\x10sources_consumed\x18\x01 \x03(\t\x12\x1d\n\x15num_tokens_per_source\x18\x02 \x01(\x05\x1aw\n\x08Response\x12\x13\n\x0bsource_name\x18\x01 \x01(\t\x12\x10\n\x08\x66rame_id\x18\x02 \x01(\x03\x12\x14\n\x0creturn_token\x18\x03 \x01(\x08\x12.\n\x0eresult_wrapper\x18\x04 \x01(\x0b\x32\x16.gabriel.ResultWrapperB\x15\n\x13welcome_or_response\"\xdf\x01\n\x14\x46romStandaloneEngine\x12\x38\n\x07welcome\x18\x01 \x01(\x0b\x32%.gabriel.FromStandaloneEngine.WelcomeH\x00\x12\x30\n\x0eresult_wrapper\x18\x02 \x01(\x0b\x32\x16.gabriel.ResultWrapperH\x00\x1a>\n\x07Welcome\x12\x13\n\x0bsource_name\x18\x01 \x01(\t\x12\x1e\n\x16\x61ll_responses_required\x18\x02 \x01(\x08\x42\x1b\n\x19welcome_or_result_wrapper*[\n\x0bPayloadType\x12\t\n\x05IMAGE\x10\x00\x12\t\n\x05VIDEO\x10\x01\x12\t\n\x05\x41UDIO\x10\x02\x12\x07\n\x03IMU\x10\x03\x12\x08\n\x04TEXT\x10\x04\x12\r\n\tANIMATION\x10\x05\x12\t\n\x05OTHER\x10\x06\x42%\n\x1b\x65\x64u.cmu.cs.gabriel.protocolB\x06Protosb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rgabriel.proto\x12\x07gabriel\x1a\x19google/protobuf/any.proto\"p\n\nInputFrame\x12*\n\x0cpayload_type\x18\x01 \x01(\x0e\x32\x14.gabriel.PayloadType\x12\x10\n\x08payloads\x18\x02 \x03(\x0c\x12$\n\x06\x65xtras\x18\x03 \x01(\x0b\x32\x14.google.protobuf.Any\"\x7f\n\nFromClient\x12\x10\n\x08\x66rame_id\x18\x01 \x01(\x03\x12\x13\n\x0bsource_name\x18\x02 \x01(\t\x12(\n\x0binput_frame\x18\x03 \x01(\x0b\x32\x13.gabriel.InputFrame\x12 \n\x18target_computation_types\x18\x04 \x03(\t\"\xdc\x03\n\rResultWrapper\x12-\n\x06status\x18\x01 \x01(\x0e\x32\x1d.gabriel.ResultWrapper.Status\x12.\n\x07results\x18\x02 \x03(\x0b\x32\x1d.gabriel.ResultWrapper.Result\x12$\n\x06\x65xtras\x18\x03 \x01(\x0b\x32\x14.google.protobuf.Any\x12@\n\x14result_producer_name\x18\x04 \x01(\x0b\x32\".gabriel.ResultWrapper.StringValue\x1a\x45\n\x06Result\x12*\n\x0cpayload_type\x18\x01 \x01(\x0e\x32\x14.gabriel.PayloadType\x12\x0f\n\x07payload\x18\x02 \x01(\x0c\x1a\x1c\n\x0bStringValue\x12\r\n\x05value\x18\x01 \x01(\t\"\x9e\x01\n\x06Status\x12\x0b\n\x07SUCCESS\x10\x00\x12\x15\n\x11UNSPECIFIED_ERROR\x10\x01\x12\x10\n\x0c\x45NGINE_ERROR\x10\x02\x12\x16\n\x12WRONG_INPUT_FORMAT\x10\x03\x12\x1d\n\x19NO_ENGINE_FOR_COMPUTATION\x10\x04\x12\r\n\tNO_TOKENS\x10\x05\x12\x18\n\x14SERVER_DROPPED_FRAME\x10\x06\"\xc7\x02\n\x08ToClient\x12,\n\x07welcome\x18\x01 \x01(\x0b\x32\x19.gabriel.ToClient.WelcomeH\x00\x12.\n\x08response\x18\x02 \x01(\x0b\x32\x1a.gabriel.ToClient.ResponseH\x00\x1aH\n\x07Welcome\x12\x1e\n\x16\x63omputations_supported\x18\x01 \x03(\t\x12\x1d\n\x15num_tokens_per_source\x18\x02 \x01(\x05\x1a|\n\x08Response\x12\x18\n\x10\x63omputation_type\x18\x01 \x01(\t\x12\x10\n\x08\x66rame_id\x18\x02 \x01(\x03\x12\x14\n\x0creturn_token\x18\x03 \x01(\x08\x12.\n\x0eresult_wrapper\x18\x04 \x01(\x0b\x32\x16.gabriel.ResultWrapperB\x15\n\x13welcome_or_response\"\xf9\x01\n\x14\x46romStandaloneEngine\x12\x38\n\x07welcome\x18\x01 \x01(\x0b\x32%.gabriel.FromStandaloneEngine.WelcomeH\x00\x12\x30\n\x0eresult_wrapper\x18\x02 \x01(\x0b\x32\x16.gabriel.ResultWrapperH\x00\x1aX\n\x07Welcome\x12\x18\n\x10\x63omputation_type\x18\x01 \x01(\t\x12\x1e\n\x16\x61ll_responses_required\x18\x02 \x01(\x08\x12\x13\n\x0b\x65ngine_name\x18\x03 \x01(\tB\x1b\n\x19welcome_or_result_wrapper*[\n\x0bPayloadType\x12\t\n\x05IMAGE\x10\x00\x12\t\n\x05VIDEO\x10\x01\x12\t\n\x05\x41UDIO\x10\x02\x12\x07\n\x03IMU\x10\x03\x12\x08\n\x04TEXT\x10\x04\x12\r\n\tANIMATION\x10\x05\x12\t\n\x05OTHER\x10\x06\x42%\n\x1b\x65\x64u.cmu.cs.gabriel.protocolB\x06Protosb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,28 +33,28 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'gabriel_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'\n\033edu.cmu.cs.gabriel.protocolB\006Protos'
-  _globals['_PAYLOADTYPE']._serialized_start=1281
-  _globals['_PAYLOADTYPE']._serialized_end=1372
+  _globals['_PAYLOADTYPE']._serialized_start=1357
+  _globals['_PAYLOADTYPE']._serialized_end=1448
   _globals['_INPUTFRAME']._serialized_start=53
   _globals['_INPUTFRAME']._serialized_end=165
   _globals['_FROMCLIENT']._serialized_start=167
-  _globals['_FROMCLIENT']._serialized_end=260
-  _globals['_RESULTWRAPPER']._serialized_start=263
-  _globals['_RESULTWRAPPER']._serialized_end=734
-  _globals['_RESULTWRAPPER_RESULT']._serialized_start=479
-  _globals['_RESULTWRAPPER_RESULT']._serialized_end=548
-  _globals['_RESULTWRAPPER_STRINGVALUE']._serialized_start=550
-  _globals['_RESULTWRAPPER_STRINGVALUE']._serialized_end=578
-  _globals['_RESULTWRAPPER_STATUS']._serialized_start=581
-  _globals['_RESULTWRAPPER_STATUS']._serialized_end=734
-  _globals['_TOCLIENT']._serialized_start=737
-  _globals['_TOCLIENT']._serialized_end=1053
-  _globals['_TOCLIENT_WELCOME']._serialized_start=843
-  _globals['_TOCLIENT_WELCOME']._serialized_end=909
-  _globals['_TOCLIENT_RESPONSE']._serialized_start=911
-  _globals['_TOCLIENT_RESPONSE']._serialized_end=1030
-  _globals['_FROMSTANDALONEENGINE']._serialized_start=1056
-  _globals['_FROMSTANDALONEENGINE']._serialized_end=1279
-  _globals['_FROMSTANDALONEENGINE_WELCOME']._serialized_start=1188
-  _globals['_FROMSTANDALONEENGINE_WELCOME']._serialized_end=1250
+  _globals['_FROMCLIENT']._serialized_end=294
+  _globals['_RESULTWRAPPER']._serialized_start=297
+  _globals['_RESULTWRAPPER']._serialized_end=773
+  _globals['_RESULTWRAPPER_RESULT']._serialized_start=513
+  _globals['_RESULTWRAPPER_RESULT']._serialized_end=582
+  _globals['_RESULTWRAPPER_STRINGVALUE']._serialized_start=584
+  _globals['_RESULTWRAPPER_STRINGVALUE']._serialized_end=612
+  _globals['_RESULTWRAPPER_STATUS']._serialized_start=615
+  _globals['_RESULTWRAPPER_STATUS']._serialized_end=773
+  _globals['_TOCLIENT']._serialized_start=776
+  _globals['_TOCLIENT']._serialized_end=1103
+  _globals['_TOCLIENT_WELCOME']._serialized_start=882
+  _globals['_TOCLIENT_WELCOME']._serialized_end=954
+  _globals['_TOCLIENT_RESPONSE']._serialized_start=956
+  _globals['_TOCLIENT_RESPONSE']._serialized_end=1080
+  _globals['_FROMSTANDALONEENGINE']._serialized_start=1106
+  _globals['_FROMSTANDALONEENGINE']._serialized_end=1355
+  _globals['_FROMSTANDALONEENGINE_WELCOME']._serialized_start=1238
+  _globals['_FROMSTANDALONEENGINE_WELCOME']._serialized_end=1326
 # @@protoc_insertion_point(module_scope)

--- a/python-client/src/gabriel_client/gabriel_client.py
+++ b/python-client/src/gabriel_client/gabriel_client.py
@@ -3,6 +3,7 @@ import asyncio
 from collections import namedtuple
 from gabriel_client.token_bucket import _TokenBucket
 import logging
+from gabriel_protocol import gabriel_pb2
 
 logger = logging.getLogger(__name__)
 
@@ -46,9 +47,9 @@ class GabrielClient(ABC):
         logger.info(f"The server can perform {len(welcome.computations_supported)} computations")
         for producer_wrapper in self.producer_wrappers:
             token_bucket = producer_wrapper.token_bucket
-            logger.info(f"Tokens available for {token_bucket}={welcome.num_tokens_per_source}")
+            logger.info(f"Tokens available for {token_bucket}={welcome.num_tokens_per_bucket}")
             token_bucket = producer_wrapper.token_bucket
-            self._token_buckets[token_bucket] = _Source(welcome.num_tokens_per_source)
+            self._token_buckets[token_bucket] = _TokenBucket(welcome.num_tokens_per_bucket)
         self._computations = welcome.computations_supported
         self._welcome_event.set()
 

--- a/python-client/src/gabriel_client/gabriel_client.py
+++ b/python-client/src/gabriel_client/gabriel_client.py
@@ -1,0 +1,78 @@
+from abc import ABC, abstractmethod
+import asyncio
+from collections import namedtuple
+from gabriel_client.token_bucket import _TokenBucket
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Represents an input that this client produces. 'producer' is the method that
+# produces inputs. 'token_bucket' is the token bucket to use for the input.
+# 'target_computation_types' is a list of computations to be performed on this
+# input.
+ProducerWrapper = namedtuple('ProducerWrapper', ['producer', 'token_bucket', 'target_computation_types'])
+
+class GabrielClient(ABC):
+
+    def __init__(self, host, port, producer_wrappers, consumer, uri_format):
+        # Whether a welcome message has been received from the server
+        self._welcome_event = asyncio.Event()
+        # The token buckets for the inputs
+        self._token_buckets = {}
+        # The computation types supported by the server
+        self._computations = []
+        self._running = True
+        self._uri = uri_format.format(host=host, port=port)
+        self.producer_wrappers = producer_wrappers
+        self.consumer = consumer
+
+    @abstractmethod
+    def launch(self, message_max_size=None):
+        pass
+
+    def stop(self):
+        self._running = False
+        logger.info('stopping server')
+
+    def _process_welcome(self, welcome):
+        """
+        Process a welcome message received from the server.
+
+        Args:
+            welcome:
+                The gabriel_pb2.ToClient.Welcome message received from the
+                server
+        """
+        logger.info(f"The server can perform {len(welcome.computations_supported)} computations")
+        for producer_wrapper in self.producer_wrappers:
+            token_bucket = producer_wrapper.token_bucket
+            logger.info(f"Tokens available for {token_bucket}={welcome.num_tokens_per_source}")
+            token_bucket = producer_wrapper.token_bucket
+            self._token_buckets[token_bucket] = _Source(welcome.num_tokens_per_source)
+        self._computations = welcome.computations_supported
+        self._welcome_event.set()
+
+    def _process_response(self, response):
+        """
+        Process a response received from the server.
+
+        Args:
+            response:
+                The gabriel_pb2.ToClient.Response message received from
+                the server
+        """
+        result_wrapper = response.result_wrapper
+        if (result_wrapper.status == gabriel_pb2.ResultWrapper.SUCCESS):
+            try:
+                self.consumer(result_wrapper)
+            except Exception as e:
+                logger.error(f"Error processing response from server: {e}")
+        elif (result_wrapper.status ==
+              gabriel_pb2.ResultWrapper.NO_ENGINE_FOR_COMPUTATION):
+            raise Exception('No engine for computation')
+        else:
+            status = result_wrapper.Status.Name(result_wrapper.status)
+            logger.error(f'Output status was: {status}')
+
+        if response.return_token:
+            self._token_buckets[response.token_bucket].return_token()

--- a/python-client/src/gabriel_client/gabriel_client.py
+++ b/python-client/src/gabriel_client/gabriel_client.py
@@ -66,6 +66,8 @@ class GabrielClient(ABC):
         if (result_wrapper.status == gabriel_pb2.ResultWrapper.SUCCESS):
             try:
                 self.consumer(result_wrapper)
+            except asyncio.CancelledError:
+                raise
             except Exception as e:
                 logger.error(f"Error processing response from server: {e}")
         elif (result_wrapper.status ==

--- a/python-client/src/gabriel_client/opencv_adapter.py
+++ b/python-client/src/gabriel_client/opencv_adapter.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 class OpencvAdapter:
     def __init__(self, preprocess, produce_extras, consume_frame,
-                 video_capture, source_name):
+                 video_capture, token_bucket, target_computation_types):
         '''
         preprocess should take one frame parameter
         produce_engine_fields takes no parameters
@@ -22,7 +22,8 @@ class OpencvAdapter:
         self._produce_extras = produce_extras
         self._consume_frame = consume_frame
         self._video_capture = video_capture
-        self._source_name = source_name
+        self._token_bucket = token_bucket
+        self._target_computation_types = target_computation_types
 
     def get_producer_wrappers(self):
         async def producer():
@@ -44,7 +45,9 @@ class OpencvAdapter:
             return input_frame
 
         return [
-            ProducerWrapper(producer=producer, source_name=self._source_name)
+            ProducerWrapper(
+                producer=producer, token_bucket=self._token_bucket,
+                target_computation_types=self._target_computation_types)
         ]
 
     def consumer(self, result_wrapper):

--- a/python-client/src/gabriel_client/token_bucket.py
+++ b/python-client/src/gabriel_client/token_bucket.py
@@ -3,7 +3,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-class _Source:
+class _TokenBucket:
     def __init__(self, num_tokens):
         self._num_tokens = num_tokens
         self._sem = asyncio.Semaphore(num_tokens)

--- a/python-client/src/gabriel_client/websocket_client.py
+++ b/python-client/src/gabriel_client/websocket_client.py
@@ -70,7 +70,6 @@ class WebsocketClient(GabrielClient):
         logger.info('Disconnected From Server')
 
     async def launch_async(self, message_max_size=None):
-        logger.info("Hello from websocket client")
         try:
             self._websocket = await websockets.client.connect(
                     self._uri, create_protocol=NoDelayProtocol,
@@ -97,7 +96,6 @@ class WebsocketClient(GabrielClient):
         try:
             _, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
         except asyncio.CancelledError:
-            logger.info("Cancelling tasks")
             for task in tasks:
                 if task.done():
                     continue
@@ -106,7 +104,6 @@ class WebsocketClient(GabrielClient):
                     await task
                 except asyncio.CancelledError:
                     pass
-            logger.info("Tasks cancelled")
             raise
         logger.info('Disconnected From Server')
 

--- a/python-client/src/gabriel_client/zeromq_client.py
+++ b/python-client/src/gabriel_client/zeromq_client.py
@@ -192,6 +192,10 @@ class ZeroMQClient(GabrielClient):
                 self._schedule_heartbeat.set()
                 await asyncio.sleep(0)
                 continue
+            except asyncio.CancelledError:
+                producer_task.cancel()
+                await producer_task
+                raise
 
             logger.debug("Got input from producer")
             producer_task = None

--- a/python-client/src/gabriel_client/zeromq_client.py
+++ b/python-client/src/gabriel_client/zeromq_client.py
@@ -6,16 +6,12 @@ import zmq.asyncio
 
 from google.protobuf.message import DecodeError
 from gabriel_protocol import gabriel_pb2
-from collections import namedtuple
+from gabriel_client.gabriel_client import GabrielClient
 from gabriel_client.source import _Source
 
 URI_FORMAT = 'tcp://{host}:{port}'
 
 logger = logging.getLogger(__name__)
-
-# Represents an input that this client produces. 'producer' is the method
-# that produces inputs and 'source_name' is the source that the inputs are for.
-ProducerWrapper = namedtuple('ProducerWrapper', ['producer', 'source_name'])
 
 # The duration of time in seconds after which the server is considered to be
 # disconnected.
@@ -30,7 +26,7 @@ HELLO_MSG = b'Hello message'
 
 context = zmq.asyncio.Context()
 
-class ZeroMQClient:
+class ZeroMQClient(GabrielClient):
     """
     A Gabriel client that talks to the server over ZeroMQ.
     """
@@ -44,16 +40,10 @@ class ZeroMQClient:
                 client
             consumer: callback for results from server
         """
+
+        super().__init__(host, port, producer_wrappers, consumer, URI_FORMAT)
         # Socket used for communicating with the server
         self._sock = context.socket(zmq.DEALER)
-        # Whether a welcome message has been received from the server
-        self._welcome_event = asyncio.Event()
-        # The input sources accepted by the server
-        self._sources = {}
-        self._running = True
-        self._uri = URI_FORMAT.format(host=host, port=port)
-        self.producer_wrappers = producer_wrappers
-        self.consumer = consumer
         # Whether the client is connected to the server
         self._connected = asyncio.Event()
         # Indicates that a heartbeat was sent to the server but a heartbeat
@@ -89,8 +79,11 @@ class ZeroMQClient:
         logger.info("Sent hello message to server")
 
         tasks = [
-            self._producer_handler(producer_wrapper.producer, producer_wrapper.source_name)
-            for producer_wrapper in self.producer_wrappers
+            self._producer_handler(
+                producer_wrapper.producer,
+                producer_wrapper.token_bucket,
+                producer_wrapper.target_computation_types
+            ) for producer_wrapper in self.producer_wrappers
         ]
         tasks.append(self._consumer_handler())
         tasks.append(self._heartbeat_loop())
@@ -148,61 +141,23 @@ class ZeroMQClient:
                 logger.critical("Fatal error: empty to_client message received from server")
                 raise Exception('Empty to_client message')
 
-    def _process_welcome(self, welcome):
-        """
-        Process a welcome message received from the server.
-
-        Args:
-            welcome:
-                The gabriel_pb2.ToClient.Welcome message received from the
-                server
-        """
-        logger.info(f"{len(welcome.sources_consumed)} sources accepted by the server")
-        for source_name in welcome.sources_consumed:
-            logger.info(f"Tokens available for source {source_name}={welcome.num_tokens_per_source}")
-            self._sources[source_name] = _Source(welcome.num_tokens_per_source)
-        self._welcome_event.set()
-
-    def _process_response(self, response):
-        """
-        Process a response received from the server.
-
-        Args:
-            response:
-                The gabriel_pb2.ToClient.Response message received from
-                the server
-        """
-        result_wrapper = response.result_wrapper
-        if (result_wrapper.status == gabriel_pb2.ResultWrapper.SUCCESS):
-            try:
-                self.consumer(result_wrapper)
-            except Exception as e:
-                logger.error(f"Error processing response from server: {e}")
-        elif (result_wrapper.status ==
-              gabriel_pb2.ResultWrapper.NO_ENGINE_FOR_SOURCE):
-            logger.critical("Fatal error: no engine for source")
-            raise Exception('No engine for source')
-        else:
-            status = result_wrapper.Status.Name(result_wrapper.status)
-            logger.error('Output status was: %s', status)
-
-        if response.return_token:
-            self._sources[response.source_name].return_token()
-
-    async def _producer_handler(self, producer, source_name):
+    async def _producer_handler(
+        self, producer, token_bucket, target_computation_types):
         """
         Loop waiting until there is a token available. Then calls producer to
         get the gabriel_pb2.InputFrame to send.
 
         Args:
             producer: The method used to produce inputs for the server
-            source_name (str): The name of the source to produce inputs for
+            token_bucket (str):
+                The name of the token bucket corresponding to the input
+            target_computation_types: the computations to be performed
         """
         await self._welcome_event.wait()
 
-        source = self._sources.get(source_name)
+        source = self._token_buckets.get(token_bucket)
         assert source is not None, (
-            "No engines consume frames from source: {}".format(source_name))
+            "No engines consume frames from source: {}".format(token_bucket))
 
         # Async task used to producer an input
         producer_task = None
@@ -248,13 +203,13 @@ class ZeroMQClient:
 
             from_client = gabriel_pb2.FromClient()
             from_client.frame_id = source.get_frame_id()
-            from_client.source_name = source_name
+            from_client.target_computation_types[:] = target_computation_types
             from_client.input_frame.CopyFrom(input_frame)
 
             # Send input to server
             await self._sock.send(from_client.SerializeToString())
 
-            logger.debug('Semaphore for %s is %s', source_name,
+            logger.debug('Semaphore for %s is %s', token_bucket,
                          "LOCKED" if source.is_locked() else "AVAILABLE")
             source.next_frame()
 

--- a/python-client/src/gabriel_client/zeromq_client.py
+++ b/python-client/src/gabriel_client/zeromq_client.py
@@ -55,13 +55,10 @@ class ZeroMQClient(GabrielClient):
 
         self._connected.set()
 
-    async def launch_async(self):
+    async def launch_async(self, message_max_size=None):
         await self._launch_helper()
 
     def launch(self, message_max_size=None):
-        """
-        Launch the client.
-        """
         asyncio.ensure_future(self._launch_helper())
         asyncio.get_event_loop().run_forever()
 
@@ -103,12 +100,11 @@ class ZeroMQClient(GabrielClient):
                 else:
                     logger.info("Still disconnected; reconnecting and resending heartbeat")
 
-                # Resend heartbeat in case it was lost
+                # Attempt to reconnect
                 self._sock.close(0)
                 self._sock = context.socket(zmq.DEALER)
                 self._sock.connect(self._uri)
 
-                # Send heartbeat even though we are disconnected
                 await self._send_heartbeat(True)
                 continue
 

--- a/server/src/gabriel_server/gabriel_server.py
+++ b/server/src/gabriel_server/gabriel_server.py
@@ -35,6 +35,7 @@ class GabrielServer(ABC):
         self._computation_types = set()
         # Indicates that the server start up is finished
         self._start_event = asyncio.Event()
+        # Whether the server is running
         self._is_running = False
         self._engine_cb = engine_cb
 
@@ -162,7 +163,7 @@ class GabrielServer(ABC):
             return ResultWrapper.Status.NO_TOKENS
 
         dropped = True
-        logger.info(f"Targetting {from_client.target_computation_types}")
+        logger.debug(f"Targetting {from_client.target_computation_types}")
         for computation_type in from_client.target_computation_types:
             if computation_type not in self._computation_types:
                 logger.error(f'No engines perform {computation_type}')

--- a/server/src/gabriel_server/gabriel_server.py
+++ b/server/src/gabriel_server/gabriel_server.py
@@ -14,21 +14,21 @@ class GabrielServer(ABC):
     and passes it to the specified callback function. Results are sent back to
     the client as they become available.
     """
-    def __init__(self, num_tokens_per_source, engine_cb):
+    def __init__(self, num_tokens_per_bucket, engine_cb):
         """
         Args:
-            num_tokens_per_source (int):
-                The number of tokens available for each source
+            num_tokens_per_bucket (int):
+                The number of tokens available for each bucket
             engine_cb:
                 Callback invoked for each input received from a client
         """
 
-        # Metadata for each client. 'tokens_for_source' is a dictionary that
-        # stores the tokens available for each source. 'task' is an async task
+        # Metadata for each client. 'tokens_for_bucket' is a dictionary that
+        # stores the tokens available for each bucket. 'task' is an async task
         # that consumes inputs from 'inputs' for each client.  'websocket' is
         # the Websockets handler for this client if using Websockets.
-        self._Client = namedtuple('_Client', ['tokens_for_source', 'inputs', 'task', 'websocket'])
-        self._num_tokens_per_source = num_tokens_per_source
+        self._Client = namedtuple('_Client', ['tokens_for_bucket', 'inputs', 'task', 'websocket'])
+        self._num_tokens_per_bucket = num_tokens_per_bucket
         # The clients connected to the server
         self._clients = {}
         # The computations consumed by the server
@@ -39,14 +39,14 @@ class GabrielServer(ABC):
         self._engine_cb = engine_cb
 
     @abstractmethod
-    def launch(self, port, message_max_size):
+    async def launch(self, port, message_max_size):
         pass
 
     async def wait_for_start(self):
         await self._start_event.wait()
 
     async def send_result_wrapper(
-        self, address, computation_type, source_name, frame_id,
+        self, engine_name, address, computation_type, token_bucket, frame_id,
         result_wrapper, return_token):
         """
         Send result to client at address.
@@ -54,26 +54,32 @@ class GabrielServer(ABC):
         Args:
             address: The identifier of the client to send the result to
             computation_type: The type of computation that the result corresponds to
-            source_name: The source of the input that the result corresponds to
+            token_bucket: The token bucket corresponding to this result
             frame_id: The frame id of the input that the result corresponds to
             result_wrapper: The result payload to send to the client
             return_token: Whether to return a token to the client
 
         Returns True if send succeeded.
         """
+
+        logger.info(f"Sending result from engine {engine_name}")
         client = self._clients.get(address)
         if client is None:
             logger.warning('Send request to invalid address: %s', address)
             return False
 
         if return_token:
-            client.tokens_for_source[source_name] += 1
+            client.tokens_for_bucket[token_bucket] += 1
 
         to_client = gabriel_pb2.ToClient()
-        to_client.response.eomputation_type = computation_type
+        to_client.response.computation_type = computation_type
         to_client.response.frame_id = frame_id
         to_client.response.return_token = return_token
         to_client.response.result_wrapper.CopyFrom(result_wrapper)
+        to_client.response.token_bucket = token_bucket
+        producer_name = gabriel_pb2.ResultWrapper.StringValue()
+        producer_name.value = engine_name
+        to_client.response.result_wrapper.result_producer_name.CopyFrom(producer_name)
 
         return await self._send_via_transport(address, to_client.SerializeToString())
 
@@ -145,29 +151,30 @@ class GabrielServer(ABC):
             address: The identifier of the client
             from_client: A FromClient protobuf message containing the input
         """
-        source_name = from_client.source_name
-        if client.tokens_for_source[source_name] < 1:
+        token_bucket = from_client.token_bucket
+        if token_bucket not in client.tokens_for_bucket:
+            client.tokens_for_bucket[token_bucket] = self._num_tokens_per_bucket
+
+        if client.tokens_for_bucket[token_bucket] < 1:
             logger.error(
-                f'Client {address} sending from source {source_name} without tokens')
+                f'Client {address} sending input without tokens in {token_bucket=}')
+            print("No tokens!")
             return ResultWrapper.Status.NO_TOKENS
 
-        input_accepted = False
         dropped = True
+        logger.info(f"Targetting {from_client.target_computation_types}")
         for computation_type in from_client.target_computation_types:
             if computation_type not in self._computation_types:
                 logger.error(f'No engines perform {computation_type}')
-            else:
-                input_accepted = True
+                return ResultWrapper.Status.NO_ENGINE_FOR_COMPUTATION
 
-            logger.debug(f'Sending input from client {address} from source {source_name} for {computation_type}')
+            logger.debug(f'Sending input from client {address} from {token_bucket=} for {computation_type}')
             send_success = await self._engine_cb(from_client, address, computation_type)
             if send_success:
                 dropped = False
             else:
                 logger.error(f'Server dropped frame from client {address} for {computation_type}')
 
-        if not input_accepted:
-            return ResultWrapper.Status.NO_ENGINE_FOR_COMPUTATION
         if dropped:
             return gabriel_pb2.ResultWrapper.Status.SERVER_DROPPED_FRAME
         return ResultWrapper.Status.SUCCESS

--- a/server/src/gabriel_server/local_engine.py
+++ b/server/src/gabriel_server/local_engine.py
@@ -24,12 +24,12 @@ def run(engine_factory, computation_type, input_queue_maxsize, port, num_tokens,
     raise Exception('Server stopped')
 
 class _LocalServer:
-    def __init__(self, num_tokens_per_source, input_queue_maxsize, conn, computation_type, use_zeromq):
+    def __init__(self, num_tokens_per_bucket, input_queue_maxsize, conn, computation_type, use_zeromq):
         self._input_queue = asyncio.Queue(input_queue_maxsize)
         self._conn = conn
         self._result_ready = asyncio.Event()
         self._server = (
-            ZeroMQServer if use_zeromq else WebsocketServer)(num_tokens_per_source, self._send_to_engine)
+            ZeroMQServer if use_zeromq else WebsocketServer)(num_tokens_per_bucket, self._send_to_engine)
         self._server.add_computation_type(computation_type)
 
     async def _send_to_engine(self, from_client, address):

--- a/server/src/gabriel_server/network_engine/engine_runner.py
+++ b/server/src/gabriel_server/network_engine/engine_runner.py
@@ -1,8 +1,9 @@
 import logging
 import zmq
+import zmq.asyncio
 from gabriel_protocol import gabriel_pb2
 from gabriel_server import network_engine
-
+import threading
 
 TEN_SECONDS = 10000
 REQUEST_RETRIES = 3
@@ -10,42 +11,107 @@ REQUEST_RETRIES = 3
 
 logger = logging.getLogger(__name__)
 
+class EngineRunner:
+
+    def __init__(self, engine, computation_type, server_address, engine_name,
+                 all_responses_required, timeout, request_retries):
+
+        self._context = zmq.Context()
+        self._stop_event = threading.Event()
+        self._engine = engine
+        self._computation_type = computation_type
+        self._server_address = server_address
+        self._engine_name = engine_name
+        self._all_responses_required = all_responses_required
+        self._timeout = timeout
+        self._request_retries = request_retries
+
+    async def run_async(self):
+        request_retries = self._request_retries
+
+        context = zmq.asyncio.Context()
+
+        while request_retries > 0 and not self._stop_event.is_set():
+            socket = context.socket(zmq.REQ)
+            socket.connect(self._server_address)
+            from_standalone_engine = gabriel_pb2.FromStandaloneEngine()
+            from_standalone_engine.welcome.computation_type = self._computation_type
+            from_standalone_engine.welcome.all_responses_required = (
+                self._all_responses_required)
+            from_standalone_engine.welcome.engine_name = self._engine_name
+            await socket.send(from_standalone_engine.SerializeToString())
+            logger.info('Sent welcome message to server')
+
+            while not self._stop_event.is_set():
+                if await socket.poll(self._timeout) == 0:
+                    logger.warning('No response from server')
+                    socket.setsockopt(zmq.LINGER, 0)
+                    socket.close()
+                    request_retries -= 1
+                    break
+
+                message_from_server = await socket.recv()
+                if message_from_server == network_engine.HEARTBEAT:
+                    await socket.send(network_engine.HEARTBEAT)
+                    continue
+
+                input_frame = gabriel_pb2.InputFrame()
+                input_frame.ParseFromString(message_from_server)
+                result_wrapper = self._engine.handle(input_frame)
+
+                from_standalone_engine = gabriel_pb2.FromStandaloneEngine()
+                from_standalone_engine.result_wrapper.CopyFrom(result_wrapper)
+                await socket.send(from_standalone_engine.SerializeToString())
+
+        if not self._stop_event.is_set():
+            logger.warning('Ran out of retries. Abandoning server connection.')
+
+    def run(self):
+        request_retries = self._request_retries
+
+        while request_retries > 0 and not self._stop_event.is_set():
+            socket = self._context.socket(zmq.REQ)
+            socket.connect(self._server_address)
+            from_standalone_engine = gabriel_pb2.FromStandaloneEngine()
+            from_standalone_engine.welcome.computation_type = self._computation_type
+            from_standalone_engine.welcome.all_responses_required = (
+                self._all_responses_required)
+            from_standalone_engine.welcome.engine_name = self._engine_name
+            socket.send(from_standalone_engine.SerializeToString())
+            logger.info('Sent welcome message to server')
+
+            while not self._stop_event.is_set():
+                if socket.poll(self._timeout) == 0:
+                    logger.warning('No response from server')
+                    socket.setsockopt(zmq.LINGER, 0)
+                    socket.close()
+                    request_retries -= 1
+                    break
+
+                message_from_server = socket.recv()
+                if message_from_server == network_engine.HEARTBEAT:
+                    socket.send(network_engine.HEARTBEAT)
+                    continue
+
+                input_frame = gabriel_pb2.InputFrame()
+                input_frame.ParseFromString(message_from_server)
+                result_wrapper = self._engine.handle(input_frame)
+
+                from_standalone_engine = gabriel_pb2.FromStandaloneEngine()
+                from_standalone_engine.result_wrapper.CopyFrom(result_wrapper)
+                socket.send(from_standalone_engine.SerializeToString())
+
+        if not self._stop_event.is_set():
+            logger.warning('Ran out of retries. Abandoning server connection.')
+
+    def stop(self):
+        self._stop_event.set()
 
 def run(engine, computation_type, server_address, engine_name,
         all_responses_required=False, timeout=TEN_SECONDS,
         request_retries=REQUEST_RETRIES):
-    context = zmq.Context()
+    engine_runner = EngineRunner(
+        engine, computation_type, server_address, engine_name,
+        all_responses_required, timeout, request_retries)
+    engine_runner.run()
 
-    while request_retries > 0:
-        socket = context.socket(zmq.REQ)
-        socket.connect(server_address)
-        from_standalone_engine = gabriel_pb2.FromStandaloneEngine()
-        from_standalone_engine.welcome.computation_type = computation_type
-        from_standalone_engine.welcome.all_responses_required = (
-            all_responses_required)
-        from_standalone_engine.welcome.engine_name = engine_name
-        socket.send(from_standalone_engine.SerializeToString())
-        logger.info('Sent welcome message to server')
-
-        while True:
-            if socket.poll(timeout) == 0:
-                logger.warning('No response from server')
-                socket.setsockopt(zmq.LINGER, 0)
-                socket.close()
-                request_retries -= 1
-                break
-
-            message_from_server = socket.recv()
-            if message_from_server == network_engine.HEARTBEAT:
-                socket.send(network_engine.HEARTBEAT)
-                continue
-
-            input_frame = gabriel_pb2.InputFrame()
-            input_frame.ParseFromString(message_from_server)
-            result_wrapper = engine.handle(input_frame)
-
-            from_standalone_engine = gabriel_pb2.FromStandaloneEngine()
-            from_standalone_engine.result_wrapper.CopyFrom(result_wrapper)
-            socket.send(from_standalone_engine.SerializeToString())
-
-    logger.warning('Ran out of retires. Abandoning server connection.')

--- a/server/src/gabriel_server/network_engine/engine_runner.py
+++ b/server/src/gabriel_server/network_engine/engine_runner.py
@@ -11,8 +11,9 @@ REQUEST_RETRIES = 3
 logger = logging.getLogger(__name__)
 
 
-def run(engine, computation_type, server_address, all_responses_required=False,
-        timeout=TEN_SECONDS, request_retries=REQUEST_RETRIES):
+def run(engine, computation_type, server_address, engine_name,
+        all_responses_required=False, timeout=TEN_SECONDS,
+        request_retries=REQUEST_RETRIES):
     context = zmq.Context()
 
     while request_retries > 0:
@@ -22,6 +23,7 @@ def run(engine, computation_type, server_address, all_responses_required=False,
         from_standalone_engine.welcome.computation_type = computation_type
         from_standalone_engine.welcome.all_responses_required = (
             all_responses_required)
+        from_standalone_engine.welcome.engine_name = engine_name
         socket.send(from_standalone_engine.SerializeToString())
         logger.info('Sent welcome message to server')
 

--- a/server/src/gabriel_server/network_engine/engine_runner.py
+++ b/server/src/gabriel_server/network_engine/engine_runner.py
@@ -11,7 +11,7 @@ REQUEST_RETRIES = 3
 logger = logging.getLogger(__name__)
 
 
-def run(engine, source_name, server_address, all_responses_required=False,
+def run(engine, computation_type, server_address, all_responses_required=False,
         timeout=TEN_SECONDS, request_retries=REQUEST_RETRIES):
     context = zmq.Context()
 
@@ -19,7 +19,7 @@ def run(engine, source_name, server_address, all_responses_required=False,
         socket = context.socket(zmq.REQ)
         socket.connect(server_address)
         from_standalone_engine = gabriel_pb2.FromStandaloneEngine()
-        from_standalone_engine.welcome.source_name = source_name
+        from_standalone_engine.welcome.computation_type = computation_type
         from_standalone_engine.welcome.all_responses_required = (
             all_responses_required)
         socket.send(from_standalone_engine.SerializeToString())

--- a/server/src/gabriel_server/network_engine/server_runner.py
+++ b/server/src/gabriel_server/network_engine/server_runner.py
@@ -41,7 +41,7 @@ class _Server:
         self._timeout = timeout
         self._size_for_queues = size_for_queues
         self._server = (
-            ZeroMQServer if use_zeromq else WebsocketServer)(num_tokens, self._send_to_engine)
+            ZeroMQServer if use_zeromq else WebsocketServer)(num_tokens, self._send_to_engine_group)
 
     async def cleanup(self):
         '''Cleanup background asyncio tasks'''
@@ -212,7 +212,7 @@ class _Server:
                 del self._engine_groups[computation_type]
                 self._server.remove_computation_type(computation_type)
 
-    async def _send_to_engine(self, from_client, client_address, computation_type):
+    async def _send_to_engine_group(self, from_client, client_address, computation_type):
         engine_group = self._engine_groups[computation_type]
         return await engine_group.process_input_from_client(
             from_client, client_address)

--- a/server/src/gabriel_server/network_engine/server_runner.py
+++ b/server/src/gabriel_server/network_engine/server_runner.py
@@ -17,7 +17,7 @@ FIVE_SECONDS = 5
 logger = logging.getLogger(__name__)
 
 
-Metadata = namedtuple('Metadata', ['frame_id', 'client_address'])
+Metadata = namedtuple('Metadata', ['frame_id', 'client_address', 'source_name'])
 
 
 MetadataPayload = namedtuple('MetadataPayload', ['metadata', 'payload'])
@@ -37,7 +37,7 @@ class _Server:
     def __init__(self, num_tokens, zmq_socket, timeout, size_for_queues, use_zeromq):
         self._zmq_socket = zmq_socket
         self._engine_workers = {}
-        self._source_infos = {}
+        self._engine_groups = {}
         self._timeout = timeout
         self._size_for_queues = size_for_queues
         self._server = (
@@ -84,13 +84,15 @@ class _Server:
 
         result_wrapper = from_standalone_engine.result_wrapper
         engine_worker_metadata = engine_worker.get_current_input_metadata()
-        source_info = engine_worker.get_source_info()
-        latest_input = source_info.get_latest_input()
+        engine_group = engine_worker.get_engine_group()
+        latest_input = engine_group.get_latest_input()
         if (latest_input is not None and
             latest_input.metadata == engine_worker_metadata):
             # Send response to client
             await self._server.send_result_wrapper(
-                engine_worker_metadata.client_address, source_info.get_name(),
+                engine_worker_metadata.client_address,
+                engine_group.computation_type(),
+                engine_worker_metadata.source_name,
                 engine_worker_metadata.frame_id, result_wrapper,
                 return_token=True)
             await engine_worker.send_message_from_queue()
@@ -98,7 +100,9 @@ class _Server:
 
         if engine_worker.get_all_responses_required():
             await self._server.send_result_wrapper(
-                engine_worker_metadata.client_address, source_info.get_name(),
+                engine_worker_metadata.client_address,
+                engine_group.computation_type(),
+                engine_worker_metadata.source_name,
                 engine_worker_metadata.frame_id, result_wrapper,
                 return_token=False)
 
@@ -116,26 +120,25 @@ class _Server:
             return
 
         welcome = from_standalone_engine.welcome
-        source_name = welcome.source_name
-        logger.info('New engine connected that consumes frames from source: %s',
-                    source_name)
+        engine_name = welcome.engine_name
+        computation_type = welcome.computation_type
+        logger.info(f'Engine {engine_name} connected that performs {computation_type}')
 
-        source_info = self._source_infos.get(source_name)
-        if source_info is None:
-            logger.info('First engine that consumes from source: %s',
-                        source_name)
-            source_info = _SourceInfo(source_name, self._size_for_queues)
-            self._source_infos[source_name] = source_info
+        engine_group = self._engine_groups.get(computation_type)
+        if engine_group is None:
+            logger.info(f'First engine connected that performs {computation_type}: {engine_name}')
+            engine_group = _EngineGroup(computation_type, self._size_for_queues)
+            self._engine_groups[computation_type] = engine_group
 
-            # Tell server to accept inputs from source_name
-            self._server.add_source_consumed(source_name)
+            # Tell server to accept inputs for this computation type
+            self._server.add_computation_type(computation_type)
 
         all_responses_required = welcome.all_responses_required
         engine_worker = _EngineWorker(
-            self._zmq_socket, source_info, address, all_responses_required)
+            self._zmq_socket, engine_group, address, name, all_responses_required)
         self._engine_workers[address] = engine_worker
 
-        source_info.add_engine_worker(engine_worker)
+        engine_group.add_engine_worker(engine_worker)
 
     async def _heartbeat_helper(self):
         current_time = time.time()
@@ -149,11 +152,10 @@ class _Server:
                 await engine_worker.send_heartbeat()
                 continue
 
-            source_info = engine_worker.get_source_info()
-            logger.info('Lost connection to engine worker that consumes items '
-                        'from source: %s', source_info.get_name())
+            engine_group = engine_worker.get_engine_group()
+            logger.info(f'Lost connection to engine worker that performs {engine_group.computation_type()}')
 
-            latest_input = source_info.get_latest_input()
+            latest_input = engine_group.get_latest_input()
             current_input_metadata = engine_worker.get_current_input_metadata()
             if (latest_input is not None and
                 current_input_metadata == latest_input.metadata):
@@ -162,41 +164,43 @@ class _Server:
                 result_wrapper = cognitive_engine.create_result_wrapper(status)
                 await self._server.send_result_wrapper(
                     current_input_metadata.client_address,
-                    source_info.get_name(), current_input_metadata.frame_id,
+                    engine_group.computation_type(), current_input_metadata.frame_id,
                     result_wrapper, return_token=True)
 
-            source_info.remove_engine_worker(engine_worker)
+            engine_group.remove_engine_worker(engine_worker)
             del self._engine_workers[address]
 
-            if source_info.has_no_engine_workers():
-                source_name = source_info.get_name()
-                logger.info('No remaining engines consume input from source: '
-                            '%s', source_name)
-                del self._source_infos[source_name]
-                self._server.remove_source_consumed(source_name)
+            if engine_group.has_no_engine_workers():
+                computation_type = engine_group.computation_type()
+                logger.info(f'No remaining engines perform {computation_type}')
+                del self._engine_groups[computation_type]
+                self._server.remove_computation_type(computation_type)
 
-    async def _send_to_engine(self, from_client, client_address):
-        source_info = self._source_infos[from_client.source_name]
-        return await source_info.process_input_from_client(
+    async def _send_to_engine(self, from_client, client_address, computation_type):
+        engine_group = self._engine_groups[computation_type]
+        return await engine_group.process_input_from_client(
             from_client, client_address)
-
 
 class _EngineWorker:
     def __init__(
-            self, zmq_socket, source_info, address, all_responses_required):
+            self, zmq_socket, engine_group, address, name, all_responses_required):
         self._zmq_socket = zmq_socket
-        self._source_info = source_info
+        self._engine_group = engine_group
         self._address = address
         self._all_responses_required = all_responses_required
         self._last_sent = 0
         self._awaiting_heartbeat_response = False
         self._current_input_metadata = None
+        self._name = name
+
+    def get_name(self):
+        return self._name
 
     def get_address(self):
         return self._address
 
-    def get_source_info(self):
-        return self._source_info
+    def get_engine_group(self):
+        return self._engine_group
 
     def get_current_input_metadata(self):
         return self._current_input_metadata
@@ -233,7 +237,7 @@ class _EngineWorker:
         '''Send message from queue and update current input.
 
         Current input will be set as None if there is nothing on the queue.'''
-        metadata_payload = self._source_info.advance_unsent_queue()
+        metadata_payload = self._engine_group.advance_unsent_queue()
 
         if metadata_payload is None:
             self._current_input_metadata = None
@@ -241,15 +245,25 @@ class _EngineWorker:
             await self.send_payload(metadata_payload)
 
 
-class _SourceInfo:
-    def __init__(self, source_name, fresh_inputs_queue_size):
-        self._source_name = source_name
+class _EngineGroup:
+    """
+    Manages a group of engines that perform the same type of computation.
+    """
+    def __init__(self, computation_type, fresh_inputs_queue_size):
+        """
+        Args:
+            computation_type (str):
+                The type of computation performed by this engine group
+            fresh_inputs_queue_size (int):
+                The size of the unsent inputs queue
+        """
+        self._computation_type = computation_type
         self._unsent_inputs = asyncio.Queue(maxsize=fresh_inputs_queue_size)
         self._latest_input = None
         self._engine_workers = set()
 
-    def get_name(self):
-        return self._source_name
+    def computation_type(self):
+        return self._engine_type
 
     def add_engine_worker(self, engine_worker):
         self._engine_workers.add(engine_worker)
@@ -266,7 +280,8 @@ class _SourceInfo:
     async def process_input_from_client(self, from_client, client_address):
         sent_to_engine = False
         metadata = Metadata(
-            frame_id=from_client.frame_id, client_address=client_address)
+            frame_id=from_client.frame_id, client_address=client_address,
+            source_name=from_client.source_name)
         payload = from_client.input_frame.SerializeToString()
         metadata_payload = MetadataPayload(metadata=metadata, payload=payload)
         for engine_worker in self._engine_workers:

--- a/server/src/gabriel_server/websocket_server.py
+++ b/server/src/gabriel_server/websocket_server.py
@@ -26,14 +26,12 @@ class WebsocketServer(GabrielServer):
         self._server = None
 
     async def launch(self, port, message_max_size):
-        start_server = websockets.server.serve(
+        async with websockets.server.serve(
             self._handler, port=port, max_size=message_max_size,
-            create_protocol=NoDelayProtocol)
-        self._server = await start_server
-        self._start_event.set()
-
-        stop = asyncio.get_running_loop().create_future()
-        await stop
+            create_protocol=NoDelayProtocol) as server:
+            self._server = server
+            self._start_event.set()
+            await server.serve_forever()
 
         # It isn't necessary to set TCP_NODELAY on self._server.sockets because
         # these are used for listening and not writing.

--- a/server/src/gabriel_server/zeromq_server.py
+++ b/server/src/gabriel_server/zeromq_server.py
@@ -21,16 +21,17 @@ HELLO_MSG = b'Hello message'
 logger = logging.getLogger(__name__)
 
 class ZeroMQServer(GabrielServer):
-    def __init__(self, num_tokens_per_source, engine_cb):
-        super().__init__(num_tokens_per_source, engine_cb)
+    def __init__(self, num_tokens_per_bucket, engine_cb):
+        super().__init__(num_tokens_per_bucket, engine_cb)
         self._is_running = False
         self._ctx = zmq.asyncio.Context()
         # The socket used for communicating with all clients
         self._sock = self._ctx.socket(zmq.ROUTER)
 
-    def launch(self, port, message_max_size):
-        asyncio.ensure_future(self._launch_helper(port))
-        asyncio.get_event_loop().run_forever()
+        self._bg_tasks = []
+
+    async def launch(self, port, message_max_size):
+        await asyncio.create_task(self._launch_helper(port))
 
     async def _launch_helper(self, port):
         """
@@ -68,6 +69,11 @@ class ZeroMQServer(GabrielServer):
         number of tokens available for each computation type.
         """
         while self._is_running:
+
+            for client_task in self._bg_tasks:
+                if client_task.done() and client_task.exception() is not None:
+                    client_task.result()
+
             # Listen for client messages
             try:
                 address, raw_input = await self._sock.recv_multipart()
@@ -82,17 +88,19 @@ class ZeroMQServer(GabrielServer):
             if client is None:
                 logger.info('New client connected: %s', address)
                 client = self._Client(
-                    tokens_for_source={},
+                    tokens_for_bucket={},
                     inputs=asyncio.Queue(),
                     task=asyncio.create_task(self._consumer(address)),
                     websocket=None)
                 self._clients[address] = client
 
+                self._bg_tasks.append(client.task)
+
                 # Send client welcome message
                 to_client = gabriel_pb2.ToClient()
                 logger.debug(f"{len(self._computation_types)} types of computation can be performed: {self._computation_types}")
                 to_client.welcome.computations_supported[:] = self._computation_types
-                to_client.welcome.num_tokens_per_source = self._num_tokens_per_source
+                to_client.welcome.num_tokens_per_bucket = self._num_tokens_per_bucket
                 await self._sock.send_multipart([
                     address,
                     to_client.SerializeToString()
@@ -150,21 +158,22 @@ class ZeroMQServer(GabrielServer):
                 continue
 
             # Consume input
+            logger.debug(f"Consuming input from client {address}, token_bucket={from_client.token_bucket}, target_computation_types={from_client.target_computation_types}")
             status = await self._consumer_helper(client, address, from_client)
 
             if status == ResultWrapper.Status.SUCCESS:
                 logger.debug("Consumed input from %s successfully", address)
-                if from_client.source_name in client.tokens_for_source:
-                    client.tokens_for_source[from_client.source_name] -= 1
+                if from_client.token_bucket in client.tokens_for_bucket:
+                    client.tokens_for_bucket[from_client.token_bucket] -= 1
                 else:
-                    client.tokens_for_source[from_client.source_name] = self._num_tokens_per_source - 1
+                    client.tokens_for_bucket[from_client.token_bucket] = self._num_tokens_per_source - 1
                 continue
 
             # Send error message
             logger.error(f"Sending error message to client {address}")
             to_client = gabriel_pb2.ToClient()
-            to_client.target_computation_types[:] = from_client.target_computation_types
             to_client.response.frame_id = from_client.frame_id
+            to_client.response.token_bucket = from_client.token_bucket
             to_client.response.return_token = True
             to_client.response.result_wrapper.status = status
             await self._sock.send_multipart([

--- a/server/src/gabriel_server/zeromq_server.py
+++ b/server/src/gabriel_server/zeromq_server.py
@@ -143,9 +143,7 @@ class ZeroMQServer(GabrielServer):
         # Consume inputs for this client as long as it is registered
         while address in self._clients:
             try:
-                logger.info("Waiting for input from client queue")
                 raw_input = await asyncio.wait_for(client.inputs.get(), CLIENT_TIMEOUT_SECS)
-                logger.info("Done waiting for input from client queue")
             except (TimeoutError, asyncio.TimeoutError):
                 logger.info(f"Client disconnected: {address}")
                 del self._clients[address]

--- a/tests/integration/basic_test.py
+++ b/tests/integration/basic_test.py
@@ -1,0 +1,230 @@
+import asyncio
+import concurrent.futures
+import itertools
+import logging
+import pytest
+import pytest_asyncio
+import threading
+import time
+
+from gabriel_client.gabriel_client import ProducerWrapper
+from gabriel_client.websocket_client import WebsocketClient
+from gabriel_client.zeromq_client import ZeroMQClient
+from gabriel_protocol import gabriel_pb2
+from gabriel_server.network_engine import server_runner
+from gabriel_server.network_engine import engine_runner
+from gabriel_server import cognitive_engine
+
+DEFAULT_NUM_TOKENS = 2
+DEFAULT_SERVER_HOST = 'localhost'
+INPUT_QUEUE_MAXSIZE = 60
+
+logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+#@pytest.fixture(scope="session")
+#def event_loop():
+#    try:
+#        loop = asyncio.get_running_loop()
+#    except RuntimeError:
+#        loop = asyncio.new_event_loop()
+#    yield loop
+#    loop.close()
+
+class Engine(cognitive_engine.Engine, threading.Thread):
+
+    def __init__(self, engine_id, computation_type, zeromq_address):
+        super().__init__()
+        self.engine_id = engine_id
+        self.computation_type = computation_type
+        self.zeromq_address = zeromq_address
+        self.engine_runner = engine_runner.EngineRunner(
+            self, self.computation_type, self.zeromq_address,
+            f"Engine-{self.engine_id}", all_responses_required=True, timeout=1000, request_retries=3)
+
+        logger.info(f"Engine {engine_id} initialized")
+
+    def handle(self, input_frame):
+        logger.info(f"Engine {self.engine_id} received frame")
+        status = gabriel_pb2.ResultWrapper.Status.SUCCESS
+        result_wrapper = cognitive_engine.create_result_wrapper(status)
+
+        result = gabriel_pb2.ResultWrapper.Result()
+        result.payload_type = gabriel_pb2.PayloadType.IMAGE
+        result.payload = input_frame.payloads[0]
+        result_wrapper.results.append(result)
+
+        return result_wrapper
+
+    def run(self):
+        self.engine_runner.run()
+
+    async def run_async(self):
+        await self.engine_runner.run_async()
+
+    def stop(self):
+        self.engine_runner.stop()
+
+@pytest.fixture(scope="session")
+def client_port_generator():
+    return itertools.count(9099)
+
+@pytest.fixture
+def client_port(client_port_generator):
+    return next(client_port_generator)
+
+@pytest.fixture(scope="session")
+def engine_port_generator():
+    return itertools.count(5555)
+
+@pytest.fixture
+def engine_port(engine_port_generator):
+    return next(engine_port_generator)
+
+@pytest.fixture
+def use_zeromq():
+    return True
+
+@pytest.fixture
+def num_engines():
+    return 1
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def run_server(client_port, engine_port, use_zeromq):
+    logger.info(f"Starting server: {use_zeromq=} {engine_port=} {client_port=}")
+    task = asyncio.create_task(server_runner.run(
+        websocket_port=client_port, zmq_address=f"tcp://*:{engine_port}",
+        num_tokens=DEFAULT_NUM_TOKENS, input_queue_maxsize=INPUT_QUEUE_MAXSIZE,
+        use_zeromq=use_zeromq))
+    yield task
+    logger.info("Tearing down server")
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+    logger.info("Done tearing down server")
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def run_engines(run_server, engine_port, num_engines):
+    engines = []
+    logger.info(f"Running engines, connecting to {engine_port=}!")
+
+    for engine_id in range(num_engines):
+        computation_type = f"computation_type-{engine_id}"
+        zeromq_address = f'tcp://localhost:{engine_port}'
+        engine = Engine(engine_id, computation_type, zeromq_address)
+        engines.append(asyncio.create_task(engine.run_async()))
+
+    yield engines
+    logger.info("Tearing down engines")
+    for task in engines:
+        task.cancel()
+    await asyncio.gather(*engines, return_exceptions=True)
+    logger.info("Done tearing down engines")
+
+@pytest.fixture
+def target_computation_types():
+    return ["computation_type-0"]
+
+@pytest.fixture
+def producer_wrappers(target_computation_types):
+    async def producer():
+        logger.info("Producing input")
+        frame = gabriel_pb2.InputFrame()
+        frame.payload_type = gabriel_pb2.PayloadType.TEXT
+        frame.payloads.append(b'Hello from client')
+        await asyncio.sleep(0.1)
+        return frame
+
+    return [
+        ProducerWrapper(producer=producer, token_bucket='default-token-bucket', target_computation_types=target_computation_types)
+    ]
+
+response_received = False
+
+def consumer(result_wrapper):
+    logger.info(f"Status is {result_wrapper.status}")
+    logger.info(f"Produced by {result_wrapper.result_producer_name.value}")
+    global response_received
+    response_received = True
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_zeromq_client(run_engines, producer_wrappers, client_port):
+    global response_received
+    response_received = False
+
+    client = ZeroMQClient(DEFAULT_SERVER_HOST, client_port, producer_wrappers, consumer)
+    task = asyncio.create_task(client.launch_async())
+    logger.info("Hello from test!")
+
+    for i in range(10):
+        await asyncio.sleep(0.1)
+        if response_received:
+            break
+    task.cancel()
+    try:
+        logger.info("Waiting for client task to cancel")
+        await task
+    except asyncio.CancelledError:
+        if asyncio.current_task().cancelled():
+            raise
+    logger.info("Client task is cancelled")
+
+    assert response_received
+
+@pytest.mark.asyncio(loop_scope="session")
+@pytest.mark.parametrize('use_zeromq', [False])
+async def test_websocket_client(producer_wrappers, client_port, run_engines):
+    logger.info(f"{client_port=}")
+    global response_received
+    response_received = False
+
+    client = WebsocketClient(DEFAULT_SERVER_HOST, client_port, producer_wrappers, consumer)
+    task = asyncio.create_task(client.launch_async())
+    logger.info("Hello from test!")
+
+
+    while True:
+        logger.info("Waiting for response from server")
+        await asyncio.sleep(0.1)
+        if response_received:
+            logger.info("Received response!")
+            break
+
+    task.cancel()
+    try:
+        logger.info("Waiting for client task to cancel")
+        await task
+    except asyncio.CancelledError:
+        if asyncio.current_task().cancelled():
+            raise
+    logger.info("Client task is cancelled")
+
+    assert response_received
+
+responses = dict()
+
+def multiple_engine_consumer(result_wrapper):
+    logger.info(f"Status is {result_wrapper.status}")
+    logger.info(f"Produced by {result_wrapper.result_producer_name.value}")
+    global responses
+    key = result_wrapper.result_producer_name.value
+    responses[key] = responses.get(key, 0) + 1
+
+@pytest.mark.asyncio(loop_scope="session")
+@pytest.mark.parametrize('target_computation_types', [["computation_type-0"], ["computation_type-0", "computation_type-1"], ["computation_type-0", "computation_type-1", "computation_type-2"]])
+@pytest.mark.parametrize('num_engines', [3])
+async def test_send_multiple_engines(producer_wrappers, client_port, target_computation_types, run_engines):
+    global responses
+    responses = dict()
+
+    logger.info(f"{client_port=}")
+
+    client = ZeroMQClient(DEFAULT_SERVER_HOST, client_port, producer_wrappers, multiple_engine_consumer)
+    task = asyncio.create_task(client.launch_async())
+
+    try:
+        await asyncio.wait_for(task, timeout=1)
+    except (TimeoutError, asyncio.TimeoutError):
+        pass
+
+    assert len(responses) == len(target_computation_types)
+

--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+#log_cli = True
+#log_cli_level = DEBUG
+asyncio_default_fixture_loop_scope = function
+#asyncio_mode = strict

--- a/tests/integration/tox.ini
+++ b/tests/integration/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py38, py39, py310, py311, py312
+isolated_build = True
+
+[testenv]
+deps =
+    -e ../../python-client
+    -e ../../server
+    -e ../../protocol/python
+    asyncio
+    pytest
+    pytest-asyncio
+    pytest-timeout
+    pytest-sugar
+commands =
+    pytest


### PR DESCRIPTION
Currently, Gabriel cognitive engines specify to the Gabriel server which inputs they want to subscribe to. This creates a static client-engine mapping that precludes the client from dynamically deciding which cognitive engines should process its input. This change makes it so that instead of cognitive engines subscribing to client inputs ("sources"), we instead invert the process and let the client specify which "engine groups" to which the inputs are sent. 

This change will support our vision of making Gabriel more scalable with many clients. A client may not always need the results from each engine and may want to decide which "computational services" it cares about dynamically. This will reduce wasteful computation and improve the resource utilization of the Gabriel backend.

This change introduces the concept of an "engine group" instead of specifying individual engines to send inputs to, along the lines of the existing "source name." Clients could subscribe to, say, object detection, and get results from multiple object detection algorithms. If desired, each engine group could also have just one engine, equivalent to specifying the individual engines the client wants to subscribe to.